### PR TITLE
Create mapping from address IDs to zipcodes

### DIFF
--- a/linkage/wic_case_study/2023_02_07a_assign_zipcodes.ipynb
+++ b/linkage/wic_case_study/2023_02_07a_assign_zipcodes.ipynb
@@ -10,9 +10,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tue 07 Feb 2023 12:19:16 PM PST\n",
+      "Thu 09 Feb 2023 10:50:17 PM PST\n",
       "ndbs\n",
-      "Linux int-slurm-sarchive-p0004 5.4.0-89-generic #100-Ubuntu SMP Fri Sep 24 14:50:10 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux\n",
+      "Linux int-slurm-sarchive-p0002 5.4.0-89-generic #100-Ubuntu SMP Fri Sep 24 14:50:10 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux\n",
       "/mnt/share/code/ndbs/vivarium_research_prl/linkage/wic_case_study\n"
      ]
     }
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "550591be",
    "metadata": {},
    "outputs": [
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "c22950b0",
    "metadata": {},
    "outputs": [
@@ -496,7 +496,7 @@
        "[50000 rows x 27 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -517,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "41321ab2",
    "metadata": {},
    "outputs": [
@@ -539,7 +539,7 @@
        "Name: address, Length: 864, dtype: int64"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -551,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "0b61583b",
    "metadata": {},
    "outputs": [
@@ -572,7 +572,7 @@
        "Name: zipcode, Length: 864, dtype: int64"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -583,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "id": "df189273",
    "metadata": {},
    "outputs": [
@@ -593,7 +593,7 @@
        "<AxesSubplot: >"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -614,7 +614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "id": "0707a780",
    "metadata": {},
    "outputs": [
@@ -624,7 +624,7 @@
        "<AxesSubplot: >"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -645,7 +645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "id": "adbb2aeb",
    "metadata": {},
    "outputs": [
@@ -666,7 +666,7 @@
        "Name: address, Length: 93, dtype: int64"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -679,7 +679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "id": "b8ba04e5",
    "metadata": {},
    "outputs": [
@@ -700,7 +700,7 @@
        "Name: zipcode, Length: 183, dtype: int64"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -721,7 +721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "id": "12145027",
    "metadata": {},
    "outputs": [
@@ -752,7 +752,7 @@
        "Name: zipcode, dtype: object"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -763,7 +763,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 12,
    "id": "a17b002c",
    "metadata": {},
    "outputs": [
@@ -794,7 +794,7 @@
        "Name: zipcode, dtype: object"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -807,7 +807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 13,
    "id": "1b591417",
    "metadata": {},
    "outputs": [
@@ -838,7 +838,7 @@
        "Name: zipcode, dtype: object"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -849,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 14,
    "id": "374ce476",
    "metadata": {},
    "outputs": [
@@ -870,7 +870,7 @@
        "Name: zipcode, Length: 50000, dtype: object"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -889,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 15,
    "id": "8a3aa3ee",
    "metadata": {},
    "outputs": [
@@ -920,7 +920,7 @@
        "Name: zipcode, dtype: object"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -939,7 +939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 16,
    "id": "42e22dc3",
    "metadata": {},
    "outputs": [
@@ -949,7 +949,7 @@
        "True"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -960,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 17,
    "id": "c43206dc",
    "metadata": {},
    "outputs": [
@@ -970,7 +970,7 @@
        "True"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -991,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 18,
    "id": "34785bad",
    "metadata": {},
    "outputs": [
@@ -1001,7 +1001,7 @@
        "20449"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1012,7 +1012,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 19,
    "id": "373aa8c2",
    "metadata": {},
    "outputs": [
@@ -1022,7 +1022,7 @@
        "246"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1033,7 +1033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 20,
    "id": "2273d835",
    "metadata": {},
    "outputs": [
@@ -1043,7 +1043,7 @@
        "207"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1054,7 +1054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 21,
    "id": "2f1c034a",
    "metadata": {},
    "outputs": [
@@ -1064,7 +1064,7 @@
        "{'NA'}"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1077,7 +1077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 22,
    "id": "9a4e118b",
    "metadata": {},
    "outputs": [
@@ -1087,7 +1087,7 @@
        "{'NA'}"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1101,7 +1101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 23,
    "id": "3c7f7c30",
    "metadata": {},
    "outputs": [
@@ -1111,7 +1111,7 @@
        "20204"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1122,7 +1122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 24,
    "id": "7cc3e507",
    "metadata": {},
    "outputs": [
@@ -1144,7 +1144,7 @@
        "Name: employer_address, Length: 207, dtype: int64"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1161,7 +1161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 25,
    "id": "c7d4806e",
    "metadata": {},
    "outputs": [
@@ -1171,7 +1171,7 @@
        "<AxesSubplot: >"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1197,12 +1197,14 @@
    "source": [
     "# Check whether all addresses have a unique zip code\n",
     "\n",
-    "## Not quite... there's one address with 2 zips"
+    "## Not quite... there's one address with 2 zips\n",
+    "\n",
+    "Let's just ignore that and take the minimum of the two when assigning zipcodes to addresses."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 26,
    "id": "9a37f039",
    "metadata": {},
    "outputs": [
@@ -1224,7 +1226,7 @@
        "Name: zipcode, Length: 20449, dtype: int64"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1236,7 +1238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 27,
    "id": "5ee306f9",
    "metadata": {},
    "outputs": [
@@ -1248,7 +1250,7 @@
        "Name: zipcode, dtype: int64"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1259,7 +1261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 28,
    "id": "4dacb2f7",
    "metadata": {},
    "outputs": [
@@ -1271,7 +1273,7 @@
        "Name: zipcode, dtype: int64"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1282,7 +1284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 29,
    "id": "f946b0b4",
    "metadata": {},
    "outputs": [
@@ -1532,7 +1534,7 @@
        "[6 rows x 27 columns]"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1543,7 +1545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 30,
    "id": "d0fe4894",
    "metadata": {},
    "outputs": [
@@ -1553,7 +1555,7 @@
        "62"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1564,7 +1566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 31,
    "id": "20ed7dcc",
    "metadata": {},
    "outputs": [
@@ -1574,7 +1576,7 @@
        "19"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1595,7 +1597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 32,
    "id": "a3916051",
    "metadata": {},
    "outputs": [
@@ -1702,7 +1704,7 @@
        "[20449 rows x 2 columns]"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1718,7 +1720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 33,
    "id": "021b9225",
    "metadata": {},
    "outputs": [
@@ -1728,7 +1730,7 @@
        "array([5])"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1742,12 +1744,14 @@
    "id": "59c1ae13",
    "metadata": {},
    "source": [
-    "# Load new census data"
+    "# Load new census data and WIC data\n",
+    "\n",
+    "The census data is missing some fraction of simulants, so we need to make sure we map all the address IDs that appear in WIC but not census."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 34,
    "id": "072d70f1",
    "metadata": {},
    "outputs": [
@@ -1771,7 +1775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 35,
    "id": "5d66ace5",
    "metadata": {},
    "outputs": [
@@ -1779,8 +1783,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 29.6 s, sys: 1.09 s, total: 30.6 s\n",
-      "Wall time: 30.8 s\n"
+      "CPU times: user 27.3 s, sys: 1.7 s, total: 29 s\n",
+      "Wall time: 29 s\n"
      ]
     },
     {
@@ -2130,7 +2134,7 @@
        "[4943285 rows x 18 columns]"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2143,7 +2147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 36,
    "id": "703ec5b8",
    "metadata": {},
    "outputs": [
@@ -2171,7 +2175,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 122,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2182,7 +2186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 37,
    "id": "25115ff0",
    "metadata": {},
    "outputs": [
@@ -2192,7 +2196,7 @@
        "Index([], dtype='object')"
       ]
      },
-     "execution_count": 124,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2202,241 +2206,19 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "c5755ef5",
-   "metadata": {},
-   "source": [
-    "# Figure out how to map each address IDs from new census data to an address (hence zipcode) in the original data\n",
-    "\n",
-    "The idea is to just mod the address ID by the number of original addresses, then use the modded ID as the index in the `address_to_zip` map.\n",
-    "\n",
-    "Ideally, the address IDs would be consecutive integers up to the maximum ID so that we're guaranteed an approximately uniform mapping into the original addresses (hence zipcodes).\n",
-    "\n",
-    "It looks like the address IDs are not quite consecutive, but there are only 77 values missing between the minimum 0 and the maximum 189,912. We could just ignore this and probably get a good enough mapping anyway. But instead, I just took all the address IDs that were greater than or equal to the number of unique IDs (189,836), and replaced each of these with one of the 77 missing values. Conveniently, each of the 77 missing values appeared only once in the dataframe, which made this very easy to do."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 68,
-   "id": "d2faee94",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "count    4.943285e+06\n",
-       "mean     7.023635e+04\n",
-       "std      5.381825e+04\n",
-       "min      0.000000e+00\n",
-       "25%      2.655600e+04\n",
-       "50%      6.048500e+04\n",
-       "75%      9.719400e+04\n",
-       "max      1.899120e+05\n",
-       "Name: address_id, dtype: float64"
-      ]
-     },
-     "execution_count": 68,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_census.address_id.describe()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 69,
-   "id": "c8993872",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "189836"
-      ]
-     },
-     "execution_count": 69,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_census.address_id.nunique()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 77,
-   "id": "1d3e4826",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "189913"
-      ]
-     },
-     "execution_count": 77,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df_census.address_id.max()+1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 80,
-   "id": "c62cc4ea",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "77"
-      ]
-     },
-     "execution_count": 80,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "189913 - 189836"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c6f656c1",
-   "metadata": {},
-   "source": [
-    "## Find missing 77 ids"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 79,
-   "id": "d107cb1c",
+   "execution_count": 38,
+   "id": "4ea55fab",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "77\n"
+      "CPU times: user 2.68 s, sys: 15.4 ms, total: 2.69 s\n",
+      "Wall time: 2.69 s\n"
      ]
     },
-    {
-     "data": {
-      "text/plain": [
-       "[108551,\n",
-       " 109068,\n",
-       " 121370,\n",
-       " 101921,\n",
-       " 94755,\n",
-       " 98370,\n",
-       " 100930,\n",
-       " 102479,\n",
-       " 100951,\n",
-       " 99418,\n",
-       " 105051,\n",
-       " 103005,\n",
-       " 113255,\n",
-       " 117351,\n",
-       " 112754,\n",
-       " 111762,\n",
-       " 115346,\n",
-       " 110228,\n",
-       " 133778,\n",
-       " 102039,\n",
-       " 100507,\n",
-       " 105120,\n",
-       " 124067,\n",
-       " 96935,\n",
-       " 105132,\n",
-       " 101562,\n",
-       " 117453,\n",
-       " 133341,\n",
-       " 101088,\n",
-       " 105705,\n",
-       " 104686,\n",
-       " 122620,\n",
-       " 99586,\n",
-       " 103690,\n",
-       " 106251,\n",
-       " 114956,\n",
-       " 107793,\n",
-       " 108311,\n",
-       " 115993,\n",
-       " 114459,\n",
-       " 112418,\n",
-       " 111397,\n",
-       " 99633,\n",
-       " 107825,\n",
-       " 99638,\n",
-       " 119126,\n",
-       " 101227,\n",
-       " 100210,\n",
-       " 99703,\n",
-       " 94072,\n",
-       " 111479,\n",
-       " 98171,\n",
-       " 119684,\n",
-       " 119187,\n",
-       " 103320,\n",
-       " 106398,\n",
-       " 106917,\n",
-       " 115622,\n",
-       " 100263,\n",
-       " 103338,\n",
-       " 101296,\n",
-       " 132027,\n",
-       " 103358,\n",
-       " 106430,\n",
-       " 103872,\n",
-       " 97731,\n",
-       " 133064,\n",
-       " 112075,\n",
-       " 96208,\n",
-       " 119249,\n",
-       " 102355,\n",
-       " 120792,\n",
-       " 114650,\n",
-       " 114143,\n",
-       " 96228,\n",
-       " 98290,\n",
-       " 99835]"
-      ]
-     },
-     "execution_count": 79,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "missing_ids = list(set(range(189913)).difference(df_census.address_id))\n",
-    "print(len(missing_ids))\n",
-    "missing_ids"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ddf4e4fb",
-   "metadata": {},
-   "source": [
-    "## Find address IDs greater than or equal to the number of unique IDs\n",
-    "\n",
-    "Conveniently, each of these only shows up once."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 82,
-   "id": "b70f28f0",
-   "metadata": {},
-   "outputs": [
     {
      "data": {
       "text/html": [
@@ -2469,9 +2251,7 @@
        "      <th>guardian_2</th>\n",
        "      <th>guardian_1_address_id</th>\n",
        "      <th>guardian_2_address_id</th>\n",
-       "      <th>relation_to_household_head</th>\n",
-       "      <th>census_year</th>\n",
-       "      <th>housing_type</th>\n",
+       "      <th>wic_year</th>\n",
        "      <th>random_seed</th>\n",
        "      <th>year_of_birth</th>\n",
        "      <th>first_name</th>\n",
@@ -2480,109 +2260,99 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1896572</th>\n",
-       "      <td>2787_188277</td>\n",
-       "      <td>188277.0</td>\n",
-       "      <td>35.636775</td>\n",
-       "      <td>Male</td>\n",
-       "      <td>White</td>\n",
-       "      <td>1994-07-31</td>\n",
-       "      <td>189836</td>\n",
-       "      <td>-1</td>\n",
-       "      <td>-1</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
-       "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>1994</td>\n",
-       "      <td>Henry</td>\n",
-       "      <td>J</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1896937</th>\n",
-       "      <td>2787_188688</td>\n",
-       "      <td>188687.0</td>\n",
-       "      <td>98.313706</td>\n",
+       "      <th>0</th>\n",
+       "      <td>7359_65</td>\n",
+       "      <td>65.0</td>\n",
+       "      <td>8.553950</td>\n",
        "      <td>Female</td>\n",
-       "      <td>White</td>\n",
-       "      <td>1931-11-26</td>\n",
-       "      <td>189837</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>2012-05-21</td>\n",
+       "      <td>35</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
-       "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>1931</td>\n",
-       "      <td>Frances</td>\n",
-       "      <td>N</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1897811</th>\n",
-       "      <td>2787_189698</td>\n",
-       "      <td>189698.0</td>\n",
-       "      <td>24.811578</td>\n",
-       "      <td>Female</td>\n",
-       "      <td>White</td>\n",
-       "      <td>2005-05-28</td>\n",
-       "      <td>189838</td>\n",
-       "      <td>-1</td>\n",
-       "      <td>-1</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
-       "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>2005</td>\n",
-       "      <td>Caroline</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>7359</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>Emma</td>\n",
        "      <td>M</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1897979</th>\n",
-       "      <td>2787_189885</td>\n",
-       "      <td>189885.0</td>\n",
-       "      <td>31.322687</td>\n",
+       "      <th>1</th>\n",
+       "      <td>7359_116</td>\n",
+       "      <td>116.0</td>\n",
+       "      <td>25.505874</td>\n",
        "      <td>Female</td>\n",
-       "      <td>White</td>\n",
-       "      <td>1998-11-22</td>\n",
-       "      <td>189839</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>1995-06-08</td>\n",
+       "      <td>53</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
-       "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>1998</td>\n",
-       "      <td>Charlie</td>\n",
-       "      <td>D</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>7359</td>\n",
+       "      <td>1995</td>\n",
+       "      <td>Isabella</td>\n",
+       "      <td>A</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1898507</th>\n",
-       "      <td>2787_190499</td>\n",
-       "      <td>190497.0</td>\n",
-       "      <td>35.613311</td>\n",
-       "      <td>Male</td>\n",
+       "      <th>2</th>\n",
+       "      <td>7359_212</td>\n",
+       "      <td>211.0</td>\n",
+       "      <td>30.291655</td>\n",
+       "      <td>Female</td>\n",
        "      <td>Latino</td>\n",
-       "      <td>1994-08-08</td>\n",
-       "      <td>189840</td>\n",
+       "      <td>1990-08-25</td>\n",
+       "      <td>88</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
-       "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>1994</td>\n",
-       "      <td>Logan</td>\n",
-       "      <td>J</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>7359</td>\n",
+       "      <td>1990</td>\n",
+       "      <td>Paige</td>\n",
+       "      <td>L</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>7359_248</td>\n",
+       "      <td>248.0</td>\n",
+       "      <td>23.891573</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>1997-01-18</td>\n",
+       "      <td>97912</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>7359</td>\n",
+       "      <td>1997</td>\n",
+       "      <td>Michelle</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>7359_267</td>\n",
+       "      <td>266.0</td>\n",
+       "      <td>37.072670</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>White</td>\n",
+       "      <td>1983-11-13</td>\n",
+       "      <td>109</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>7359</td>\n",
+       "      <td>1983</td>\n",
+       "      <td>Maria</td>\n",
+       "      <td>A</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -2602,279 +2372,626 @@
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1946255</th>\n",
-       "      <td>2787_245536</td>\n",
-       "      <td>245536.0</td>\n",
-       "      <td>26.515258</td>\n",
-       "      <td>Female</td>\n",
-       "      <td>White</td>\n",
-       "      <td>2003-09-13</td>\n",
-       "      <td>189908</td>\n",
-       "      <td>-1</td>\n",
-       "      <td>-1</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
-       "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>2003</td>\n",
-       "      <td>Sophie</td>\n",
-       "      <td>A</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1947110</th>\n",
-       "      <td>2787_246525</td>\n",
-       "      <td>246525.0</td>\n",
-       "      <td>67.512967</td>\n",
+       "      <th>593011</th>\n",
+       "      <td>5020_277602</td>\n",
+       "      <td>231367.0</td>\n",
+       "      <td>0.041138</td>\n",
        "      <td>Male</td>\n",
-       "      <td>White</td>\n",
-       "      <td>1962-09-14</td>\n",
-       "      <td>189909</td>\n",
+       "      <td>Asian</td>\n",
+       "      <td>2030-01-08</td>\n",
+       "      <td>152642</td>\n",
+       "      <td>231367</td>\n",
        "      <td>-1</td>\n",
-       "      <td>-1</td>\n",
+       "      <td>152642.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
        "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>1962</td>\n",
-       "      <td>Wayne</td>\n",
-       "      <td>G</td>\n",
+       "      <td>5020</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Grayson</td>\n",
+       "      <td>B</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1947123</th>\n",
-       "      <td>2787_246540</td>\n",
-       "      <td>246540.0</td>\n",
-       "      <td>30.324946</td>\n",
+       "      <th>593012</th>\n",
+       "      <td>5020_277607</td>\n",
+       "      <td>237489.0</td>\n",
+       "      <td>0.045699</td>\n",
        "      <td>Male</td>\n",
-       "      <td>Black</td>\n",
-       "      <td>1999-11-22</td>\n",
-       "      <td>189910</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>2030-01-07</td>\n",
+       "      <td>135561</td>\n",
+       "      <td>237490</td>\n",
        "      <td>-1</td>\n",
-       "      <td>-1</td>\n",
+       "      <td>135561.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
        "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>1999</td>\n",
-       "      <td>Hunter</td>\n",
-       "      <td>J</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1948532</th>\n",
-       "      <td>2787_248368</td>\n",
-       "      <td>248368.0</td>\n",
-       "      <td>28.082727</td>\n",
-       "      <td>Male</td>\n",
-       "      <td>White</td>\n",
-       "      <td>2002-02-18</td>\n",
-       "      <td>189911</td>\n",
-       "      <td>-1</td>\n",
-       "      <td>-1</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
+       "      <td>5020</td>\n",
        "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>2002</td>\n",
-       "      <td>Kevin</td>\n",
+       "      <td>Tanner</td>\n",
        "      <td>E</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1948986</th>\n",
-       "      <td>2787_248950</td>\n",
-       "      <td>248950.0</td>\n",
-       "      <td>33.690303</td>\n",
-       "      <td>Male</td>\n",
-       "      <td>Multiracial or Other</td>\n",
-       "      <td>1996-07-11</td>\n",
-       "      <td>189912</td>\n",
+       "      <th>593013</th>\n",
+       "      <td>5020_277612</td>\n",
+       "      <td>242914.0</td>\n",
+       "      <td>0.039537</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Asian</td>\n",
+       "      <td>2030-01-09</td>\n",
+       "      <td>167694</td>\n",
+       "      <td>242914</td>\n",
        "      <td>-1</td>\n",
-       "      <td>-1</td>\n",
+       "      <td>167694.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Reference person</td>\n",
        "      <td>2030</td>\n",
-       "      <td>Standard</td>\n",
-       "      <td>2787</td>\n",
-       "      <td>1996</td>\n",
-       "      <td>Daniel</td>\n",
-       "      <td>M</td>\n",
+       "      <td>5020</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Madison</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>593014</th>\n",
+       "      <td>5020_277617</td>\n",
+       "      <td>5210.0</td>\n",
+       "      <td>0.054807</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>2030-01-03</td>\n",
+       "      <td>97484</td>\n",
+       "      <td>5214</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>97484.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>5020</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Gavin</td>\n",
+       "      <td>J</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>593015</th>\n",
+       "      <td>5020_277618</td>\n",
+       "      <td>69575.0</td>\n",
+       "      <td>0.034841</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>2030-01-11</td>\n",
+       "      <td>182110</td>\n",
+       "      <td>69577</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>182110.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>5020</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Eliza</td>\n",
+       "      <td>S</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>77 rows × 18 columns</p>\n",
+       "<p>593016 rows × 16 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "         simulant_id  last_name_id        age     sex        race_ethnicity  \\\n",
-       "1896572  2787_188277      188277.0  35.636775    Male                 White   \n",
-       "1896937  2787_188688      188687.0  98.313706  Female                 White   \n",
-       "1897811  2787_189698      189698.0  24.811578  Female                 White   \n",
-       "1897979  2787_189885      189885.0  31.322687  Female                 White   \n",
-       "1898507  2787_190499      190497.0  35.613311    Male                Latino   \n",
-       "...              ...           ...        ...     ...                   ...   \n",
-       "1946255  2787_245536      245536.0  26.515258  Female                 White   \n",
-       "1947110  2787_246525      246525.0  67.512967    Male                 White   \n",
-       "1947123  2787_246540      246540.0  30.324946    Male                 Black   \n",
-       "1948532  2787_248368      248368.0  28.082727    Male                 White   \n",
-       "1948986  2787_248950      248950.0  33.690303    Male  Multiracial or Other   \n",
+       "        simulant_id  last_name_id        age     sex race_ethnicity  \\\n",
+       "0           7359_65          65.0   8.553950  Female          Black   \n",
+       "1          7359_116         116.0  25.505874  Female          Black   \n",
+       "2          7359_212         211.0  30.291655  Female         Latino   \n",
+       "3          7359_248         248.0  23.891573  Female          Black   \n",
+       "4          7359_267         266.0  37.072670  Female          White   \n",
+       "...             ...           ...        ...     ...            ...   \n",
+       "593011  5020_277602      231367.0   0.041138    Male          Asian   \n",
+       "593012  5020_277607      237489.0   0.045699    Male         Latino   \n",
+       "593013  5020_277612      242914.0   0.039537  Female          Asian   \n",
+       "593014  5020_277617        5210.0   0.054807    Male         Latino   \n",
+       "593015  5020_277618       69575.0   0.034841  Female          Black   \n",
        "\n",
-       "        date_of_birth  address_id  guardian_1  guardian_2  \\\n",
-       "1896572    1994-07-31      189836          -1          -1   \n",
-       "1896937    1931-11-26      189837          -1          -1   \n",
-       "1897811    2005-05-28      189838          -1          -1   \n",
-       "1897979    1998-11-22      189839          -1          -1   \n",
-       "1898507    1994-08-08      189840          -1          -1   \n",
-       "...               ...         ...         ...         ...   \n",
-       "1946255    2003-09-13      189908          -1          -1   \n",
-       "1947110    1962-09-14      189909          -1          -1   \n",
-       "1947123    1999-11-22      189910          -1          -1   \n",
-       "1948532    2002-02-18      189911          -1          -1   \n",
-       "1948986    1996-07-11      189912          -1          -1   \n",
+       "       date_of_birth  address_id  guardian_1  guardian_2  \\\n",
+       "0         2012-05-21          35          -1          -1   \n",
+       "1         1995-06-08          53          -1          -1   \n",
+       "2         1990-08-25          88          -1          -1   \n",
+       "3         1997-01-18       97912          -1          -1   \n",
+       "4         1983-11-13         109          -1          -1   \n",
+       "...              ...         ...         ...         ...   \n",
+       "593011    2030-01-08      152642      231367          -1   \n",
+       "593012    2030-01-07      135561      237490          -1   \n",
+       "593013    2030-01-09      167694      242914          -1   \n",
+       "593014    2030-01-03       97484        5214          -1   \n",
+       "593015    2030-01-11      182110       69577          -1   \n",
        "\n",
-       "         guardian_1_address_id  guardian_2_address_id  \\\n",
-       "1896572                    NaN                    NaN   \n",
-       "1896937                    NaN                    NaN   \n",
-       "1897811                    NaN                    NaN   \n",
-       "1897979                    NaN                    NaN   \n",
-       "1898507                    NaN                    NaN   \n",
-       "...                        ...                    ...   \n",
-       "1946255                    NaN                    NaN   \n",
-       "1947110                    NaN                    NaN   \n",
-       "1947123                    NaN                    NaN   \n",
-       "1948532                    NaN                    NaN   \n",
-       "1948986                    NaN                    NaN   \n",
+       "        guardian_1_address_id  guardian_2_address_id  wic_year  random_seed  \\\n",
+       "0                         NaN                    NaN      2021         7359   \n",
+       "1                         NaN                    NaN      2021         7359   \n",
+       "2                         NaN                    NaN      2021         7359   \n",
+       "3                         NaN                    NaN      2021         7359   \n",
+       "4                         NaN                    NaN      2021         7359   \n",
+       "...                       ...                    ...       ...          ...   \n",
+       "593011               152642.0                    NaN      2030         5020   \n",
+       "593012               135561.0                    NaN      2030         5020   \n",
+       "593013               167694.0                    NaN      2030         5020   \n",
+       "593014                97484.0                    NaN      2030         5020   \n",
+       "593015               182110.0                    NaN      2030         5020   \n",
        "\n",
-       "        relation_to_household_head  census_year housing_type  random_seed  \\\n",
-       "1896572           Reference person         2030     Standard         2787   \n",
-       "1896937           Reference person         2030     Standard         2787   \n",
-       "1897811           Reference person         2030     Standard         2787   \n",
-       "1897979           Reference person         2030     Standard         2787   \n",
-       "1898507           Reference person         2030     Standard         2787   \n",
-       "...                            ...          ...          ...          ...   \n",
-       "1946255           Reference person         2030     Standard         2787   \n",
-       "1947110           Reference person         2030     Standard         2787   \n",
-       "1947123           Reference person         2030     Standard         2787   \n",
-       "1948532           Reference person         2030     Standard         2787   \n",
-       "1948986           Reference person         2030     Standard         2787   \n",
+       "        year_of_birth first_name middle_initial  \n",
+       "0                2012       Emma              M  \n",
+       "1                1995   Isabella              A  \n",
+       "2                1990      Paige              L  \n",
+       "3                1997   Michelle              M  \n",
+       "4                1983      Maria              A  \n",
+       "...               ...        ...            ...  \n",
+       "593011           2030    Grayson              B  \n",
+       "593012           2030     Tanner              E  \n",
+       "593013           2030    Madison              S  \n",
+       "593014           2030      Gavin              J  \n",
+       "593015           2030      Eliza              S  \n",
        "\n",
-       "         year_of_birth first_name middle_initial  \n",
-       "1896572           1994      Henry              J  \n",
-       "1896937           1931    Frances              N  \n",
-       "1897811           2005   Caroline              M  \n",
-       "1897979           1998    Charlie              D  \n",
-       "1898507           1994      Logan              J  \n",
-       "...                ...        ...            ...  \n",
-       "1946255           2003     Sophie              A  \n",
-       "1947110           1962      Wayne              G  \n",
-       "1947123           1999     Hunter              J  \n",
-       "1948532           2002      Kevin              E  \n",
-       "1948986           1996     Daniel              M  \n",
-       "\n",
-       "[77 rows x 18 columns]"
+       "[593016 rows x 16 columns]"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_census.query(\"address_id >= 189836\")"
+    "%%time\n",
+    "df_wic = pd.read_csv(f'{new_data_dir}/wic_observer.csv.bz2')\n",
+    "df_wic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "802b72d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "simulant_id               object\n",
+       "last_name_id             float64\n",
+       "age                      float64\n",
+       "sex                       object\n",
+       "race_ethnicity            object\n",
+       "date_of_birth             object\n",
+       "address_id                 int64\n",
+       "guardian_1                 int64\n",
+       "guardian_2                 int64\n",
+       "guardian_1_address_id    float64\n",
+       "guardian_2_address_id    float64\n",
+       "wic_year                   int64\n",
+       "random_seed                int64\n",
+       "year_of_birth              int64\n",
+       "first_name                object\n",
+       "middle_initial            object\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_wic.dtypes"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1170bbab",
+   "id": "c5755ef5",
    "metadata": {},
    "source": [
-    "## Make the address IDs consecutive by replacing each of the 77 above IDs with one of the missing IDs"
+    "# Figure out how to map each address IDs from new census data to an address (hence zipcode) in the original data\n",
+    "\n",
+    "The idea is to just mod the address ID by the number of original addresses (20,449), then use the modded ID as the index in the `address_to_zip` map.\n",
+    "\n",
+    "Ideally, the address IDs would be consecutive integers up to the maximum ID so that we're guaranteed an approximately uniform mapping into the original addresses (hence zipcodes).\n",
+    "\n",
+    "It looks like the census address IDs are not quite consecutive, but there are only 77 values missing between the minimum 0 and the maximum 189,912. Most likely, the address IDs actually _are_ consecutive, and the missing IDs are due to the missing simulants in the census. So probably (hopefully) at least some of these addresses will be present in WIC.\n",
+    "\n",
+    "Assuming that's the case, we can look at the maximum of all the address IDs that occur in either the census or WIC data, and assume that every possible address ID is a number between 0 and this maximum (inclusive). After checking below, there are no IDs in WIC that are larger than the max ID of 189,912 in the census, so we use this as the maximum possible ID. Thus we get a mapping of address IDs into the original addresses (hence zipcodes) by taking n mod 20,449 for each n in {0, ..., 189,912}."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d14b0483",
+   "metadata": {},
+   "source": [
+    "## Look at address IDs in census"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
-   "id": "facba84b",
+   "execution_count": 40,
+   "id": "d2faee94",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0               6\n",
-       "1               6\n",
-       "2               6\n",
-       "3               7\n",
-       "4               8\n",
-       "            ...  \n",
-       "4943280    150569\n",
-       "4943281         3\n",
-       "4943282     96003\n",
-       "4943283    179963\n",
-       "4943284     77605\n",
-       "Name: address_id, Length: 4943285, dtype: int64"
+       "count    4.943285e+06\n",
+       "mean     7.023635e+04\n",
+       "std      5.381825e+04\n",
+       "min      0.000000e+00\n",
+       "25%      2.655600e+04\n",
+       "50%      6.048500e+04\n",
+       "75%      9.719400e+04\n",
+       "max      1.899120e+05\n",
+       "Name: address_id, dtype: float64"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "new_address_ids = df_census.address_id.copy()\n",
-    "new_address_ids.loc[new_address_ids >= 189836] = missing_ids\n",
-    "new_address_ids"
+    "df_census.address_id.describe()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
-   "id": "4372af3b",
+   "execution_count": 41,
+   "id": "c8993872",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "True"
+       "189836"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "set(new_address_ids).difference(df_census.address_id) == set(missing_ids)"
+    "df_census.address_id.nunique()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
-   "id": "789fe871",
+   "execution_count": 42,
+   "id": "1d3e4826",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "set()"
+       "189913"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "set(range(189836)).difference(new_address_ids)"
+    "df_census.address_id.max()+1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "c62cc4ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "77"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "189913 - 189836"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "466a3d70",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Census num unique: 189836\n",
+      "Census range length: 189913\n",
+      "Census num missing: 77\n"
+     ]
+    }
+   ],
+   "source": [
+    "census_nunique = df_census.address_id.nunique()\n",
+    "census_range_length = df_census.address_id.max()+1\n",
+    "print('Census num unique:', census_nunique)\n",
+    "print('Census range length:', census_range_length)\n",
+    "print('Census num missing:', census_range_length - census_nunique)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6f656c1",
+   "metadata": {},
+   "source": [
+    "## Find missing 77 ids in census"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "d107cb1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "77\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{94072,\n",
+       " 94755,\n",
+       " 96208,\n",
+       " 96228,\n",
+       " 96935,\n",
+       " 97731,\n",
+       " 98171,\n",
+       " 98290,\n",
+       " 98370,\n",
+       " 99418,\n",
+       " 99586,\n",
+       " 99633,\n",
+       " 99638,\n",
+       " 99703,\n",
+       " 99835,\n",
+       " 100210,\n",
+       " 100263,\n",
+       " 100507,\n",
+       " 100930,\n",
+       " 100951,\n",
+       " 101088,\n",
+       " 101227,\n",
+       " 101296,\n",
+       " 101562,\n",
+       " 101921,\n",
+       " 102039,\n",
+       " 102355,\n",
+       " 102479,\n",
+       " 103005,\n",
+       " 103320,\n",
+       " 103338,\n",
+       " 103358,\n",
+       " 103690,\n",
+       " 103872,\n",
+       " 104686,\n",
+       " 105051,\n",
+       " 105120,\n",
+       " 105132,\n",
+       " 105705,\n",
+       " 106251,\n",
+       " 106398,\n",
+       " 106430,\n",
+       " 106917,\n",
+       " 107793,\n",
+       " 107825,\n",
+       " 108311,\n",
+       " 108551,\n",
+       " 109068,\n",
+       " 110228,\n",
+       " 111397,\n",
+       " 111479,\n",
+       " 111762,\n",
+       " 112075,\n",
+       " 112418,\n",
+       " 112754,\n",
+       " 113255,\n",
+       " 114143,\n",
+       " 114459,\n",
+       " 114650,\n",
+       " 114956,\n",
+       " 115346,\n",
+       " 115622,\n",
+       " 115993,\n",
+       " 117351,\n",
+       " 117453,\n",
+       " 119126,\n",
+       " 119187,\n",
+       " 119249,\n",
+       " 119684,\n",
+       " 120792,\n",
+       " 121370,\n",
+       " 122620,\n",
+       " 124067,\n",
+       " 132027,\n",
+       " 133064,\n",
+       " 133341,\n",
+       " 133778}"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "missing_ids = set(range(census_range_length)).difference(df_census.address_id)\n",
+    "print(len(missing_ids))\n",
+    "missing_ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a82a149",
+   "metadata": {},
+   "source": [
+    "## Look at address IDs in WIC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "991202b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WIC num unique: 123789\n",
+      "WIC range length: 187855\n",
+      "WIC num missing: 64066\n"
+     ]
+    }
+   ],
+   "source": [
+    "wic_nunique = df_wic.address_id.nunique()\n",
+    "wic_range_length = df_wic.address_id.max()+1\n",
+    "print('WIC num unique:', wic_nunique)\n",
+    "print('WIC range length:', wic_range_length)\n",
+    "print('WIC num missing:', wic_range_length - wic_nunique)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cdd5910",
+   "metadata": {},
+   "source": [
+    "## 61 of the 77 missing address IDs in the census show up in WIC (note that WIC has 10 years worth of data, 2021-2030)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "e176793f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "61\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{96208,\n",
+       " 96228,\n",
+       " 97731,\n",
+       " 98171,\n",
+       " 98290,\n",
+       " 98370,\n",
+       " 99418,\n",
+       " 99586,\n",
+       " 99633,\n",
+       " 99638,\n",
+       " 99703,\n",
+       " 99835,\n",
+       " 100210,\n",
+       " 100263,\n",
+       " 100507,\n",
+       " 100930,\n",
+       " 100951,\n",
+       " 101088,\n",
+       " 101227,\n",
+       " 101296,\n",
+       " 101562,\n",
+       " 101921,\n",
+       " 102039,\n",
+       " 102355,\n",
+       " 102479,\n",
+       " 103005,\n",
+       " 103320,\n",
+       " 103338,\n",
+       " 103690,\n",
+       " 104686,\n",
+       " 105051,\n",
+       " 105120,\n",
+       " 105705,\n",
+       " 106251,\n",
+       " 106430,\n",
+       " 106917,\n",
+       " 107825,\n",
+       " 108311,\n",
+       " 108551,\n",
+       " 109068,\n",
+       " 110228,\n",
+       " 111479,\n",
+       " 111762,\n",
+       " 112418,\n",
+       " 112754,\n",
+       " 113255,\n",
+       " 114143,\n",
+       " 114650,\n",
+       " 114956,\n",
+       " 115622,\n",
+       " 117453,\n",
+       " 119187,\n",
+       " 119249,\n",
+       " 119684,\n",
+       " 120792,\n",
+       " 121370,\n",
+       " 122620,\n",
+       " 124067,\n",
+       " 132027,\n",
+       " 133341,\n",
+       " 133778}"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "missing_ids_in_wic = missing_ids.intersection(df_wic.address_id)\n",
+    "print(len(missing_ids_in_wic))\n",
+    "missing_ids_in_wic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5df611a9",
+   "metadata": {},
+   "source": [
+    "## Find maximum+1 of all address IDs encountered in Census or WIC\n",
+    "\n",
+    "The census range maximum is larger than the WIC range maximum, which is the most probable situation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "6bb237e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "census_range_length=189913, wic_range_length=187855\n",
+      "Overall range length =  189913 (Census)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'{census_range_length=}, {wic_range_length=}')\n",
+    "print('Overall range length = ',\n",
+    "      range_length := max([census_range_length, wic_range_length]),\n",
+    "      '(Census)' if range_length == census_range_length else '(WIC)'\n",
+    "     )"
    ]
   },
   {
@@ -2887,7 +3004,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 49,
+   "id": "27a4bd3f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([     0,      1,      2, ..., 189910, 189911, 189912])"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Use the overall maximum range to create a list of all possible address IDs\n",
+    "all_address_ids = np.arange(range_length)\n",
+    "all_address_ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "4b8af6ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20449"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Total number of unique original addresses\n",
+    "len(address_to_zip)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
    "id": "39b3d0a0",
    "metadata": {},
    "outputs": [
@@ -2912,8 +3074,183 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>index_of_orig_address</th>\n",
+       "      <th>orig_address</th>\n",
+       "      <th>zipcode</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>address_id</th>\n",
-       "      <th>consecutive_address_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>100th ave sw  arcadia, fl</td>\n",
+       "      <td>34266</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>109th ave sw  unincorporated, fl</td>\n",
+       "      <td>33434</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>10th street  unincorporated, fl</td>\n",
+       "      <td>32807</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>11th ave ne  cape coral, fl</td>\n",
+       "      <td>33993</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>12th ave  ormond beach, fl</td>\n",
+       "      <td>32174</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>189908</th>\n",
+       "      <td>5867</td>\n",
+       "      <td>1685 nugget ct  ft myers, fl</td>\n",
+       "      <td>33908</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>189909</th>\n",
+       "      <td>5868</td>\n",
+       "      <td>16852 76th ave  jacksonville, fl</td>\n",
+       "      <td>32217</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>189910</th>\n",
+       "      <td>5869</td>\n",
+       "      <td>16855 florence vw dr  defuniak springs, fl</td>\n",
+       "      <td>32433</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>189911</th>\n",
+       "      <td>5870</td>\n",
+       "      <td>1686 gary av  homestead, fl</td>\n",
+       "      <td>33033</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>189912</th>\n",
+       "      <td>5871</td>\n",
+       "      <td>1686 ruby lee dr  nrt port, fl</td>\n",
+       "      <td>33981</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>189913 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            index_of_orig_address                                orig_address  \\\n",
+       "address_id                                                                      \n",
+       "0                               0                   100th ave sw  arcadia, fl   \n",
+       "1                               1            109th ave sw  unincorporated, fl   \n",
+       "2                               2             10th street  unincorporated, fl   \n",
+       "3                               3                 11th ave ne  cape coral, fl   \n",
+       "4                               4                  12th ave  ormond beach, fl   \n",
+       "...                           ...                                         ...   \n",
+       "189908                       5867                1685 nugget ct  ft myers, fl   \n",
+       "189909                       5868            16852 76th ave  jacksonville, fl   \n",
+       "189910                       5869  16855 florence vw dr  defuniak springs, fl   \n",
+       "189911                       5870                 1686 gary av  homestead, fl   \n",
+       "189912                       5871              1686 ruby lee dr  nrt port, fl   \n",
+       "\n",
+       "           zipcode  \n",
+       "address_id          \n",
+       "0            34266  \n",
+       "1            33434  \n",
+       "2            32807  \n",
+       "3            33993  \n",
+       "4            32174  \n",
+       "...            ...  \n",
+       "189908       33908  \n",
+       "189909       32217  \n",
+       "189910       32433  \n",
+       "189911       33033  \n",
+       "189912       33981  \n",
+       "\n",
+       "[189913 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "address_id_to_zip = (\n",
+    "    pd.DataFrame(\n",
+    "        {'index_of_orig_address': all_address_ids % len(address_to_zip)},\n",
+    "        index=all_address_ids\n",
+    "    )\n",
+    "    .rename_axis('address_id')\n",
+    "    .join(address_to_zip, on='index_of_orig_address')\n",
+    "    .rename(columns={'address': 'orig_address', 'clean_zipcode': 'zipcode'})\n",
+    ")\n",
+    "address_id_to_zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3359df6",
+   "metadata": {},
+   "source": [
+    "# Join the zipcodes onto the census data and check distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "e3b6dc46",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 645 ms, sys: 0 ns, total: 645 ms\n",
+      "Wall time: 644 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>address_id</th>\n",
        "      <th>index_of_orig_address</th>\n",
        "      <th>orig_address</th>\n",
        "      <th>zipcode</th>\n",
@@ -2924,13 +3261,11 @@
        "      <th>0</th>\n",
        "      <td>6</td>\n",
        "      <td>6</td>\n",
-       "      <td>6</td>\n",
        "      <td>13th ave w  unincorporated, fl</td>\n",
        "      <td>33462</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>6</td>\n",
        "      <td>6</td>\n",
        "      <td>6</td>\n",
        "      <td>13th ave w  unincorporated, fl</td>\n",
@@ -2940,7 +3275,6 @@
        "      <th>2</th>\n",
        "      <td>6</td>\n",
        "      <td>6</td>\n",
-       "      <td>6</td>\n",
        "      <td>13th ave w  unincorporated, fl</td>\n",
        "      <td>33462</td>\n",
        "    </tr>\n",
@@ -2948,13 +3282,11 @@
        "      <th>3</th>\n",
        "      <td>7</td>\n",
        "      <td>7</td>\n",
-       "      <td>7</td>\n",
        "      <td>13th avenue southwest  lakeland, fl</td>\n",
        "      <td>33811</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>8</td>\n",
        "      <td>8</td>\n",
        "      <td>8</td>\n",
        "      <td>14th street  fern prk, fl</td>\n",
@@ -2966,11 +3298,9 @@
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
-       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4943280</th>\n",
-       "      <td>150569</td>\n",
        "      <td>150569</td>\n",
        "      <td>7426</td>\n",
        "      <td>2025 e roosevelt ct  kissimmee, fl</td>\n",
@@ -2980,13 +3310,11 @@
        "      <th>4943281</th>\n",
        "      <td>3</td>\n",
        "      <td>3</td>\n",
-       "      <td>3</td>\n",
        "      <td>11th ave ne  cape coral, fl</td>\n",
        "      <td>33993</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4943282</th>\n",
-       "      <td>96003</td>\n",
        "      <td>96003</td>\n",
        "      <td>14207</td>\n",
        "      <td>4647 coleherne road  winter park, fl</td>\n",
@@ -2995,7 +3323,6 @@
        "    <tr>\n",
        "      <th>4943283</th>\n",
        "      <td>179963</td>\n",
-       "      <td>179963</td>\n",
        "      <td>16371</td>\n",
        "      <td>605 tce hill ln  englewood, fl</td>\n",
        "      <td>34224</td>\n",
@@ -3003,29 +3330,28 @@
        "    <tr>\n",
        "      <th>4943284</th>\n",
        "      <td>77605</td>\n",
-       "      <td>77605</td>\n",
        "      <td>16258</td>\n",
        "      <td>6000 kirk rd  cape coral, fl</td>\n",
        "      <td>33914</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>4943285 rows × 5 columns</p>\n",
+       "<p>4943285 rows × 4 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "         address_id  consecutive_address_id  index_of_orig_address  \\\n",
-       "0                 6                       6                      6   \n",
-       "1                 6                       6                      6   \n",
-       "2                 6                       6                      6   \n",
-       "3                 7                       7                      7   \n",
-       "4                 8                       8                      8   \n",
-       "...             ...                     ...                    ...   \n",
-       "4943280      150569                  150569                   7426   \n",
-       "4943281           3                       3                      3   \n",
-       "4943282       96003                   96003                  14207   \n",
-       "4943283      179963                  179963                  16371   \n",
-       "4943284       77605                   77605                  16258   \n",
+       "         address_id  index_of_orig_address  \\\n",
+       "0                 6                      6   \n",
+       "1                 6                      6   \n",
+       "2                 6                      6   \n",
+       "3                 7                      7   \n",
+       "4                 8                      8   \n",
+       "...             ...                    ...   \n",
+       "4943280      150569                   7426   \n",
+       "4943281           3                      3   \n",
+       "4943282       96003                  14207   \n",
+       "4943283      179963                  16371   \n",
+       "4943284       77605                  16258   \n",
        "\n",
        "                                 orig_address zipcode  \n",
        "0              13th ave w  unincorporated, fl   33462  \n",
@@ -3040,33 +3366,23 @@
        "4943283        605 tce hill ln  englewood, fl   34224  \n",
        "4943284          6000 kirk rd  cape coral, fl   33914  \n",
        "\n",
-       "[4943285 rows x 5 columns]"
+       "[4943285 rows x 4 columns]"
       ]
      },
-     "execution_count": 116,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "census_zips = (\n",
-    "    pd.DataFrame(\n",
-    "        {\n",
-    "            'address_id': df_census['address_id'],\n",
-    "            'consecutive_address_id': new_address_ids,\n",
-    "            'index_of_orig_address': new_address_ids % len(address_to_zip)\n",
-    "        },\n",
-    "        index=df_census.index\n",
-    "    )\n",
-    "    .join(address_to_zip, on='index_of_orig_address')\n",
-    "    .rename(columns={'address': 'orig_address', 'clean_zipcode': 'zipcode'})\n",
-    ")\n",
+    "%%time\n",
+    "census_zips = df_census[['address_id']].join(address_id_to_zip, on='address_id')\n",
     "census_zips"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 53,
    "id": "f40186f2",
    "metadata": {},
    "outputs": [
@@ -3082,13 +3398,13 @@
        "        ... \n",
        "34987     63\n",
        "34990    249\n",
-       "34994    141\n",
+       "34994    140\n",
        "34996    169\n",
        "34997    260\n",
        "Name: address_id, Length: 857, dtype: int64"
       ]
      },
-     "execution_count": 117,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3100,7 +3416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 54,
    "id": "dd1937e4",
    "metadata": {},
    "outputs": [
@@ -3110,18 +3426,18 @@
        "9      38\n",
        "18     18\n",
        "19     13\n",
+       "46     12\n",
        "38     12\n",
-       "46     11\n",
        "       ..\n",
-       "277     1\n",
-       "539     1\n",
-       "262     1\n",
-       "279     1\n",
+       "179     1\n",
+       "386     1\n",
+       "338     1\n",
+       "340     1\n",
        "59      1\n",
-       "Name: address_id, Length: 357, dtype: int64"
+       "Name: address_id, Length: 353, dtype: int64"
       ]
      },
-     "execution_count": 118,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3132,7 +3448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 55,
    "id": "d33f7d5e",
    "metadata": {},
    "outputs": [
@@ -3142,13 +3458,13 @@
        "<AxesSubplot: >"
       ]
      },
-     "execution_count": 119,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGdCAYAAACyzRGfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAs/0lEQVR4nO3dfXSU5YH+8WsCwyQRJpEgCZEEsi4VFHxZMDDCthUDWZYqlhytQi1Fjq41voR0UdkKBtTy0lOgugFql8b11IiyK7RYhcaoWA7hLYqKdiNu0VhDwvqSDJBmGMn9+8NfpkwSIJMM9zAz3885OXGe5577ua9JQi6fPDPjMMYYAQAAWJIQ6QUAAID4QvkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYFXvSC+gvdbWVtXV1alfv35yOByRXg4AAOgCY4yOHDmizMxMJSSc/tzGOVc+6urqlJWVFellAACAbvjkk080ePDg044558pHv379JH29eLfb3eP5/H6//vCHP2jy5MlyOp09ni+akJ3sZI8v8Zyf7JHP7vV6lZWVFfg9fjrnXPlo+1OL2+0OW/lITk6W2+2Oy29IspM9nsRzdim+85P93MnelUsmuOAUAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABW9Y70Amwb+uDvg25/tHRqhFYCAEB84swHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAqpDKx4kTJ7RgwQLl5OQoKSlJF110kR555BEZYwJjjDFauHChBg0apKSkJOXl5enAgQNhXzgAAIhOIZWPZcuWac2aNfr3f/93/elPf9KyZcu0fPlyPfHEE4Exy5cv1+OPP661a9dq165dOu+885Sfn6+WlpawLx4AAESf3qEM3rFjh6ZNm6apU79+G/qhQ4fq2Wef1e7duyV9fdZj1apVeuihhzRt2jRJ0tNPP6309HRt2rRJN998c5iXDwAAok1I5ePqq6/Wk08+qQ8++EDf+MY39Pbbb2v79u1asWKFJOngwYOqr69XXl5e4D4pKSkaO3asqqqqOi0fPp9PPp8vcNvr9UqS/H6//H5/t0KdrG2Ots+uXqbT/bGoffZ4Qnayx6N4zk/2yGcP5fgOc/IFG2fQ2tqqf/u3f9Py5cvVq1cvnThxQo899pjmz58v6eszI+PHj1ddXZ0GDRoUuN9NN90kh8Oh5557rsOcJSUlWrRoUYft5eXlSk5O7nIQAAAQOc3NzZoxY4aamprkdrtPOzakMx/PP/+8nnnmGZWXl+vSSy/Vvn37VFRUpMzMTM2aNatbi50/f76Ki4sDt71er7KysjR58uQzLr4r/H6/KioqNGnSJDmdTo0s2Rq0f39Jfo+Pca5qnz2ekJ3s8ZZdiu/8ZI989ra/XHRFSOVj3rx5evDBBwN/Phk1apQ+/vhjLVmyRLNmzVJGRoYkqaGhIejMR0NDg6644opO53S5XHK5XB22O53OsD6IbfP5Tjg6bI914X4sownZyR6P4jk/2SOXPZRjh/Rsl+bmZiUkBN+lV69eam1tlSTl5OQoIyNDlZWVgf1er1e7du2Sx+MJ5VAAACBGhXTm47rrrtNjjz2m7OxsXXrppXrrrbe0YsUK3XbbbZIkh8OhoqIiPfrooxo2bJhycnK0YMECZWZm6oYbbjgb6wcAAFEmpPLxxBNPaMGCBbrrrrt0+PBhZWZm6l/+5V+0cOHCwJj7779fx44d0x133KHGxkZNmDBBW7ZsUWJiYtgXDwAAok9I5aNfv35atWqVVq1adcoxDodDixcv1uLFi3u6NgAAEIN4bxcAAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVoVUPoYOHSqHw9Hho7CwUJLU0tKiwsJCpaWlqW/fviooKFBDQ8NZWTgAAIhOIZWPPXv26NChQ4GPiooKSdKNN94oSZo7d642b96sDRs2aNu2baqrq9P06dPDv2oAABC1eocy+IILLgi6vXTpUl100UX61re+paamJq1bt07l5eWaOHGiJKmsrEwjRozQzp07NW7cuPCtGgAARK2QysfJjh8/rt/85jcqLi6Ww+FQdXW1/H6/8vLyAmOGDx+u7OxsVVVVnbJ8+Hw++Xy+wG2v1ytJ8vv98vv93V1eQNscbZ9dvUyn+2NR++zxhOxkj0fxnJ/skc8eyvEdxhhz5mEdPf/885oxY4Zqa2uVmZmp8vJyzZ49O6hISFJubq6uueYaLVu2rNN5SkpKtGjRog7by8vLlZyc3J2lAQAAy5qbmzVjxgw1NTXJ7Xafdmy3z3ysW7dOU6ZMUWZmZnenkCTNnz9fxcXFgdter1dZWVmaPHnyGRffFX6/XxUVFZo0aZKcTqdGlmwN2r+/JL/HxzhXtc8eT8hO9njLLsV3frJHPnvbXy66olvl4+OPP9Yrr7yiF154IbAtIyNDx48fV2Njo1JTUwPbGxoalJGRccq5XC6XXC5Xh+1OpzOsD2LbfL4Tjg7bY124H8toQnayx6N4zk/2yGUP5djdep2PsrIyDRw4UFOnTg1sGz16tJxOpyorKwPbampqVFtbK4/H053DAACAGBTymY/W1laVlZVp1qxZ6t37b3dPSUnRnDlzVFxcrP79+8vtduuee+6Rx+PhmS4AACAg5PLxyiuvqLa2VrfddluHfStXrlRCQoIKCgrk8/mUn5+v1atXh2WhAAAgNoRcPiZPnqxTPUEmMTFRpaWlKi0t7fHCAABAbOK9XQAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYFXL5+PTTT/X9739faWlpSkpK0qhRo7R3797AfmOMFi5cqEGDBikpKUl5eXk6cOBAWBcNAACiV0jl48svv9T48ePldDr18ssv6/3339fPf/5znX/++YExy5cv1+OPP661a9dq165dOu+885Sfn6+WlpawLx4AAESf3qEMXrZsmbKyslRWVhbYlpOTE/hvY4xWrVqlhx56SNOmTZMkPf3000pPT9emTZt08803h2nZAAAgWoVUPn73u98pPz9fN954o7Zt26YLL7xQd911l26//XZJ0sGDB1VfX6+8vLzAfVJSUjR27FhVVVV1Wj58Pp98Pl/gttfrlST5/X75/f5uhTpZ2xxtn129TKf7Y1H77PGE7GSPR/Gcn+yRzx7K8R3GGHPmYV9LTEyUJBUXF+vGG2/Unj17dN9992nt2rWaNWuWduzYofHjx6uurk6DBg0K3O+mm26Sw+HQc88912HOkpISLVq0qMP28vJyJScndzkIAACInObmZs2YMUNNTU1yu92nHRtS+ejTp4/GjBmjHTt2BLbde++92rNnj6qqqrpVPjo785GVlaXPPvvsjIvvCr/fr4qKCk2aNElOp1MjS7YG7d9fkt/jY5yr2mePJ2Qne7xll+I7P9kjn93r9WrAgAFdKh8h/dll0KBBuuSSS4K2jRgxQv/93/8tScrIyJAkNTQ0BJWPhoYGXXHFFZ3O6XK55HK5Omx3Op1hfRDb5vOdcHTYHuvC/VhGE7KTPR7Fc36yRy57KMcO6dku48ePV01NTdC2Dz74QEOGDJH09cWnGRkZqqysDOz3er3atWuXPB5PKIcCAAAxKqQzH3PnztXVV1+tn/70p7rpppu0e/duPfnkk3ryySclSQ6HQ0VFRXr00Uc1bNgw5eTkaMGCBcrMzNQNN9xwNtYPAACiTEjl46qrrtLGjRs1f/58LV68WDk5OVq1apVmzpwZGHP//ffr2LFjuuOOO9TY2KgJEyZoy5YtgYtVAQBAfAupfEjSd77zHX3nO9855X6Hw6HFixdr8eLFPVoYAACITby3CwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrQiofJSUlcjgcQR/Dhw8P7G9paVFhYaHS0tLUt29fFRQUqKGhIeyLBgAA0SvkMx+XXnqpDh06FPjYvn17YN/cuXO1efNmbdiwQdu2bVNdXZ2mT58e1gUDAIDo1jvkO/TurYyMjA7bm5qatG7dOpWXl2vixImSpLKyMo0YMUI7d+7UuHHjer5aAAAQ9UIuHwcOHFBmZqYSExPl8Xi0ZMkSZWdnq7q6Wn6/X3l5eYGxw4cPV3Z2tqqqqk5ZPnw+n3w+X+C21+uVJPn9fvn9/lCX10HbHG2fXb1Mp/tjUfvs8YTsZI9H8Zyf7JHPHsrxHcYYc+ZhX3v55Zd19OhRXXzxxTp06JAWLVqkTz/9VPv379fmzZs1e/bsoCIhSbm5ubrmmmu0bNmyTucsKSnRokWLOmwvLy9XcnJyl4MAAIDIaW5u1owZM9TU1CS3233asSGVj/YaGxs1ZMgQrVixQklJSd0qH52d+cjKytJnn312xsV3hd/vV0VFhSZNmiSn06mRJVuD9u8vye/xMc5V7bPHE7KTPd6yS/Gdn+yRz+71ejVgwIAulY+Q/+xystTUVH3jG9/Qhx9+qEmTJun48eNqbGxUampqYExDQ0On14i0cblccrlcHbY7nc6wPoht8/lOODpsj3XhfiyjCdnJHo/iOT/ZI5c9lGP36HU+jh49qv/93//VoEGDNHr0aDmdTlVWVgb219TUqLa2Vh6PpyeHAQAAMSSkMx//+q//quuuu05DhgxRXV2dHn74YfXq1Uu33HKLUlJSNGfOHBUXF6t///5yu92655575PF4eKYLAAAICKl8/OUvf9Ett9yizz//XBdccIEmTJignTt36oILLpAkrVy5UgkJCSooKJDP51N+fr5Wr159VhYOAACiU0jlY/369afdn5iYqNLSUpWWlvZoUQAAIHbx3i4AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsKpH5WPp0qVyOBwqKioKbGtpaVFhYaHS0tLUt29fFRQUqKGhoafrBAAAMaLb5WPPnj365S9/qcsuuyxo+9y5c7V582Zt2LBB27ZtU11dnaZPn97jhQIAgNjQrfJx9OhRzZw5U7/61a90/vnnB7Y3NTVp3bp1WrFihSZOnKjRo0errKxMO3bs0M6dO8O2aAAAEL26VT4KCws1depU5eXlBW2vrq6W3+8P2j58+HBlZ2erqqqqZysFAAAxoXeod1i/fr3efPNN7dmzp8O++vp69enTR6mpqUHb09PTVV9f3+l8Pp9PPp8vcNvr9UqS/H6//H5/qMvroG2Ots+uXqbT/bGoffZ4Qnayx6N4zk/2yGcP5fghlY9PPvlE9913nyoqKpSYmBjywjqzZMkSLVq0qMP2P/zhD0pOTg7LMSSpoqJCkrQ8N3j7Sy+9FLZjnKvasscjsseneM4uxXd+skdOc3Nzl8c6jDHmzMO+tmnTJn33u99Vr169AttOnDghh8OhhIQEbd26VXl5efryyy+Dzn4MGTJERUVFmjt3boc5OzvzkZWVpc8++0xut7vLQU7F7/eroqJCkyZNktPp1MiSrUH795fk9/gYkjrM2925wzWP1DF7PCE72eMtuxTf+cke+exer1cDBgxQU1PTGX9/h3Tm49prr9W7774btG327NkaPny4HnjgAWVlZcnpdKqyslIFBQWSpJqaGtXW1srj8XQ6p8vlksvl6rDd6XSG9UFsm893wtFhezi0n7e7c4drnvb3j7cfxjZkJ3s8iuf8ZI9c9lCOHVL56Nevn0aOHBm07bzzzlNaWlpg+5w5c1RcXKz+/fvL7Xbrnnvukcfj0bhx40I5FAAAiFEhX3B6JitXrlRCQoIKCgrk8/mUn5+v1atXh/swAAAgSvW4fLz++utBtxMTE1VaWqrS0tKeTg0AAGIQ7+0CAACsonwAAACrKB8xrO1puyNLtmrog7+P8GoAAPga5QMAAFhF+QAAAFZRPgAAgFVhf52PaNPZtRAfLZ0agZUAABAfOPMBAACsonwAAACrKB8AAMCquL/mozNdeU0MrgsBAKB7OPMBAACsonwAAACrKB8AAMAqygcAALCKC04t4gXNAADgzAcAALCM8gEAAKyifAAAAKu45iMKtL9WJJzXiZzNuQEA6AxnPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFgVUvlYs2aNLrvsMrndbrndbnk8Hr388suB/S0tLSosLFRaWpr69u2rgoICNTQ0hH3RAAAgeoVUPgYPHqylS5equrpae/fu1cSJEzVt2jS99957kqS5c+dq8+bN2rBhg7Zt26a6ujpNnz79rCwcAABEp5De1fa6664Luv3YY49pzZo12rlzpwYPHqx169apvLxcEydOlCSVlZVpxIgR2rlzp8aNGxe+VQMAgKjV7Ws+Tpw4ofXr1+vYsWPyeDyqrq6W3+9XXl5eYMzw4cOVnZ2tqqqqsCwWAABEv5DOfEjSu+++K4/Ho5aWFvXt21cbN27UJZdcon379qlPnz5KTU0NGp+enq76+vpTzufz+eTz+QK3vV6vJMnv98vv94e6vA7a5mj77OplejznyfO16WzecI05031OxZVggj53dr/2xwvHY34uaP91jydkj8/sUnznJ3vks4dyfIcxJqTfxsePH1dtba2ampr0X//1X/qP//gPbdu2Tfv27dPs2bODioQk5ebm6pprrtGyZcs6na+kpESLFi3qsL28vFzJycmhLA0AAERIc3OzZsyYoaamJrnd7tOODbl8tJeXl6eLLrpI3/ve93Tttdfqyy+/DDr7MWTIEBUVFWnu3Lmd3r+zMx9ZWVn67LPPzrj4rvD7/aqoqNCkSZPkdDo1smRrj+eUpP0l+UG3O5s3XGO6sx5JGr14ix4Z06oFexPka3V0Oqb98TobE43af93jCdnjM7sU3/nJHvnsXq9XAwYM6FL5CPnPLu21trbK5/Np9OjRcjqdqqysVEFBgSSppqZGtbW18ng8p7y/y+WSy+XqsN3pdIb1QWybz3fCEbb5TtbZvOEa0531SJKv1RH47Dvh6HxMu+PF2g9tuL+PognZ4zO7FN/5yR657KEcO6TyMX/+fE2ZMkXZ2dk6cuSIysvL9frrr2vr1q1KSUnRnDlzVFxcrP79+8vtduuee+6Rx+PhmS4AACAgpPJx+PBh/eAHP9ChQ4eUkpKiyy67TFu3btWkSZMkSStXrlRCQoIKCgrk8/mUn5+v1atXn5WFAwCA6BRS+Vi3bt1p9ycmJqq0tFSlpaU9WhQAAIhdvLcLAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKzq8Suc4tSGPvj7SC8hyLm2HgBAfOLMBwAAsIryAQAArKJ8AAAAq7jmI0Z0dj2Hq1cEFgIAwBlw5gMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAVbyyHsGj/xnYfLZ0aoZUAAM51nPkAAABWUT4AAIBVlA8AAGAV13wgSPtrNySu3wAAhBdnPgAAgFWUDwAAYBXlAwAAWBVS+ViyZImuuuoq9evXTwMHDtQNN9ygmpqaoDEtLS0qLCxUWlqa+vbtq4KCAjU0NIR10QAAIHqFVD62bdumwsJC7dy5UxUVFfL7/Zo8ebKOHTsWGDN37lxt3rxZGzZs0LZt21RXV6fp06eHfeEAACA6hfRsly1btgTdfuqppzRw4EBVV1frm9/8ppqamrRu3TqVl5dr4sSJkqSysjKNGDFCO3fu1Lhx48K3cgAAEJV69FTbpqYmSVL//v0lSdXV1fL7/crLywuMGT58uLKzs1VVVdVp+fD5fPL5fIHbXq9XkuT3++X3+3uyvMA8J3929TI9nvPk+dp0d95wzdMZV4IJ+txdXfk6tF93OL52PdH+6x5PyB6f2aX4zk/2yGcP5fgOY0y3fjO1trbq+uuvV2Njo7Zv3y5JKi8v1+zZs4PKhCTl5ubqmmuu0bJlyzrMU1JSokWLFnXYXl5eruTk5O4sDQAAWNbc3KwZM2aoqalJbrf7tGO7feajsLBQ+/fvDxSP7po/f76Ki4sDt71er7KysjR58uQzLr4r/H6/KioqNGnSJDmdTo0s2drjOcNpf0l+0O1wrs+VYPTImFYt2JsgX6uj2/O0X2Nn2q+7K/c5m9p/3eMJ2eMzuxTf+cke+extf7noim6Vj7vvvlsvvvii3njjDQ0ePDiwPSMjQ8ePH1djY6NSU1MD2xsaGpSRkdHpXC6XSy6Xq8N2p9MZ1gexbT7fie7/Ej4b2mc8G+vztTp6NG9Xvg7t5z9XfvjD/X0UTcgen9ml+M5P9shlD+XYIT3bxRiju+++Wxs3btSrr76qnJycoP2jR4+W0+lUZWVlYFtNTY1qa2vl8XhCORQAAIhRIZ35KCwsVHl5uX7729+qX79+qq+vlySlpKQoKSlJKSkpmjNnjoqLi9W/f3+53W7dc8898ng8PNMFAABICrF8rFmzRpL07W9/O2h7WVmZfvjDH0qSVq5cqYSEBBUUFMjn8yk/P1+rV68Oy2JxbujszecAAOiqkMpHV54Yk5iYqNLSUpWWlnZ7UQAAIHbx3i4AAMAqygcAALCqR69wCpxKZ9eFfLR0agRWAgA413DmAwAAWEX5AAAAVlE+AACAVVzzgTPidT0AAOHEmQ8AAGAV5QMAAFhF+QAAAFZxzUeExfP1FLwWCADEJ858AAAAqygfAADAKsoHAACwims+cE7juhAAiD2c+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYxYuMwZquvIlePL/RHgDEC858AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALAq5PLxxhtv6LrrrlNmZqYcDoc2bdoUtN8Yo4ULF2rQoEFKSkpSXl6eDhw4EK71AgCAKBdy+Th27Jguv/xylZaWdrp/+fLlevzxx7V27Vrt2rVL5513nvLz89XS0tLjxQIAgOgX8iucTpkyRVOmTOl0nzFGq1at0kMPPaRp06ZJkp5++mmlp6dr06ZNuvnmm3u2WgAAEPXC+vLqBw8eVH19vfLy8gLbUlJSNHbsWFVVVXVaPnw+n3w+X+C21+uVJPn9fvn9/h6vqW2Ots+uXqbHc0YLV4IJ+hwruvJ90f7rHk/IHp/ZpfjOT/bIZw/l+A5jTLd/MzkcDm3cuFE33HCDJGnHjh0aP3686urqNGjQoMC4m266SQ6HQ88991yHOUpKSrRo0aIO28vLy5WcnNzdpQEAAIuam5s1Y8YMNTU1ye12n3ZsxN9Ybv78+SouLg7c9nq9ysrK0uTJk8+4+K7w+/2qqKjQpEmT5HQ6NbJka4/njBauBKNHxrRqwd4E+VodkV7OWbO/JL/DtvZf9860/17obJ5o1JXssSqes0vxnZ/skc/e9peLrghr+cjIyJAkNTQ0BJ35aGho0BVXXNHpfVwul1wuV4ftTqczrA9i23y+E7H7S/hUfK2OmM59uu+T030ftX9MYu0frHD/DEWTeM4uxXd+skcueyjHDuvrfOTk5CgjI0OVlZWBbV6vV7t27ZLH4wnnoQAAQJQK+czH0aNH9eGHHwZuHzx4UPv27VP//v2VnZ2toqIiPfrooxo2bJhycnK0YMECZWZmBq4LAQAA8S3k8rF3715dc801gdtt12vMmjVLTz31lO6//34dO3ZMd9xxhxobGzVhwgRt2bJFiYmJ4Vs1cA4Z+uDvg25/tHRqhFYCANEh5PLx7W9/W6d7gozD4dDixYu1ePHiHi0MAADEJt7bBQAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWRfy9XYCeav86G5J04JHJZxxjUyRfC6Sz7LwWCYBI4swHAACwivIBAACsonwAAACruOYDMWlkyVYtz/36s++Eo9vzRPpaEQCIRZz5AAAAVlE+AACAVZQPAABgFdd8AGHWletEuvLaG7w+B4BYxZkPAABgFeUDAABYRfkAAABWUT4AAIBVXHAKRJGuvEFdV15gLZJvdAcAnPkAAABWUT4AAIBVlA8AAGAV13wA54hYeBO7rmToyvUlvMAaENs48wEAAKyifAAAAKsoHwAAwCqu+QD+v1i45iKcuvJaIOF6zHjsT+9sXgPDa77EvnPxGirOfAAAAKsoHwAAwCrKBwAAsOqsXfNRWlqqn/3sZ6qvr9fll1+uJ554Qrm5uWfrcEBc6uxvua5e4ZnnXNOVNR54ZPIZ79Od1xnpyvUu4Xr9krP5tejK3OG6PuBcvM6gO7gm5uw4K2c+nnvuORUXF+vhhx/Wm2++qcsvv1z5+fk6fPjw2TgcAACIImelfKxYsUK33367Zs+erUsuuURr165VcnKyfv3rX5+NwwEAgCgS9j+7HD9+XNXV1Zo/f35gW0JCgvLy8lRVVdVhvM/nk8/nC9xuamqSJH3xxRfy+/09Xo/f71dzc7M+//xzOZ1O9f7qWI/njBa9W42am1vV25+gE62dv7V6rCJ7+LN//vnnHY/VjZ+ncM1zqrnP9PPe2fHPtJ6urLk783Z2v64+Fp0dr/2/d105fnePdSbdfey760zZu6s7X2fbuvN1Pxs5jhw5Ikkyxpx5sAmzTz/91EgyO3bsCNo+b948k5ub22H8ww8/bCTxwQcffPDBBx8x8PHJJ5+csStE/EXG5s+fr+Li4sDt1tZWffHFF0pLS5PD0fP/a/N6vcrKytInn3wit9vd4/miCdnJTvb4Es/5yR757MYYHTlyRJmZmWccG/byMWDAAPXq1UsNDQ1B2xsaGpSRkdFhvMvlksvlCtqWmpoa7mXJ7XbH3TdkG7KTPd7Ec3YpvvOTPbLZU1JSujQu7Bec9unTR6NHj1ZlZWVgW2trqyorK+XxeMJ9OAAAEGXOyp9diouLNWvWLI0ZM0a5ublatWqVjh07ptmzZ5+NwwEAgChyVsrH9773Pf3f//2fFi5cqPr6el1xxRXasmWL0tPTz8bhTsvlcunhhx/u8KedeEB2ssebeM4uxXd+skdXdocxXXlODAAAQHjw3i4AAMAqygcAALCK8gEAAKyifAAAAKtivnyUlpZq6NChSkxM1NixY7V79+5IL6lHlixZoquuukr9+vXTwIEDdcMNN6impiZoTEtLiwoLC5WWlqa+ffuqoKCgw4u+1dbWaurUqUpOTtbAgQM1b948ffXVVzaj9NjSpUvlcDhUVFQU2BbL2T/99FN9//vfV1pampKSkjRq1Cjt3bs3sN8Yo4ULF2rQoEFKSkpSXl6eDhw4EDTHF198oZkzZ8rtdis1NVVz5szR0aNHbUcJyYkTJ7RgwQLl5OQoKSlJF110kR555JGg94+IpexvvPGGrrvuOmVmZsrhcGjTpk1B+8OV9Z133tE//uM/KjExUVlZWVq+fPnZjnZGp8vu9/v1wAMPaNSoUTrvvPOUmZmpH/zgB6qrqwuaIxazt3fnnXfK4XBo1apVQdujKnvP383l3LV+/XrTp08f8+tf/9q899575vbbbzepqammoaEh0kvrtvz8fFNWVmb2799v9u3bZ/75n//ZZGdnm6NHjwbG3HnnnSYrK8tUVlaavXv3mnHjxpmrr746sP+rr74yI0eONHl5eeatt94yL730khkwYICZP39+JCJ1y+7du83QoUPNZZddZu67777A9ljN/sUXX5ghQ4aYH/7wh2bXrl3mz3/+s9m6dav58MMPA2OWLl1qUlJSzKZNm8zbb79trr/+epOTk2P++te/Bsb80z/9k7n88svNzp07zR//+Efz93//9+aWW26JRKQue+yxx0xaWpp58cUXzcGDB82GDRtM3759zS9+8YvAmFjK/tJLL5mf/OQn5oUXXjCSzMaNG4P2hyNrU1OTSU9PNzNnzjT79+83zz77rElKSjK//OUvbcXs1OmyNzY2mry8PPPcc8+Z//mf/zFVVVUmNzfXjB49OmiOWMx+shdeeMFcfvnlJjMz06xcuTJoXzRlj+nykZubawoLCwO3T5w4YTIzM82SJUsiuKrwOnz4sJFktm3bZoz5+gfU6XSaDRs2BMb86U9/MpJMVVWVMebrb/KEhARTX18fGLNmzRrjdruNz+ezG6Abjhw5YoYNG2YqKirMt771rUD5iOXsDzzwgJkwYcIp97e2tpqMjAzzs5/9LLCtsbHRuFwu8+yzzxpjjHn//feNJLNnz57AmJdfftk4HA7z6aefnr3F99DUqVPNbbfdFrRt+vTpZubMmcaY2M7e/pdQuLKuXr3anH/++UHf8w888IC5+OKLz3KirjvdL+A2u3fvNpLMxx9/bIyJ/ex/+ctfzIUXXmj2799vhgwZElQ+oi17zP7Z5fjx46qurlZeXl5gW0JCgvLy8lRVVRXBlYVXU1OTJKl///6SpOrqavn9/qDcw4cPV3Z2diB3VVWVRo0aFfSib/n5+fJ6vXrvvfcsrr57CgsLNXXq1KCMUmxn/93vfqcxY8boxhtv1MCBA3XllVfqV7/6VWD/wYMHVV9fH5Q9JSVFY8eODcqempqqMWPGBMbk5eUpISFBu3btshcmRFdffbUqKyv1wQcfSJLefvttbd++XVOmTJEU29nbC1fWqqoqffOb31SfPn0CY/Lz81VTU6Mvv/zSUpqea2pqksPhCLwfWCxnb21t1a233qp58+bp0ksv7bA/2rLHbPn47LPPdOLEiQ6vqpqenq76+voIrSq8WltbVVRUpPHjx2vkyJGSpPr6evXp06fDm/OdnLu+vr7Tx6Vt37ls/fr1evPNN7VkyZIO+2I5+5///GetWbNGw4YN09atW/WjH/1I9957r/7zP/9T0t/Wfrrv9/r6eg0cODBof+/evdW/f/9zOvuDDz6om2++WcOHD5fT6dSVV16poqIizZw5U1JsZ28vXFmj9efgZC0tLXrggQd0yy23BN5MLZazL1u2TL1799a9997b6f5oy35WXl4ddhQWFmr//v3avn17pJdixSeffKL77rtPFRUVSkxMjPRyrGptbdWYMWP005/+VJJ05ZVXav/+/Vq7dq1mzZoV4dWdXc8//7yeeeYZlZeX69JLL9W+fftUVFSkzMzMmM+Ozvn9ft10000yxmjNmjWRXs5ZV11drV/84hd688035XA4Ir2csIjZMx8DBgxQr169OjzToaGhQRkZGRFaVfjcfffdevHFF/Xaa69p8ODBge0ZGRk6fvy4Ghsbg8afnDsjI6PTx6Vt37mqurpahw8f1j/8wz+od+/e6t27t7Zt26bHH39cvXv3Vnp6esxmHzRokC655JKgbSNGjFBtba2kv639dN/vGRkZOnz4cND+r776Sl988cU5nX3evHmBsx+jRo3Srbfeqrlz5wbOfsVy9vbClTVafw6kvxWPjz/+WBUVFUFvIR+r2f/4xz/q8OHDys7ODvzb9/HHH+vHP/6xhg4dKin6ssds+ejTp49Gjx6tysrKwLbW1lZVVlbK4/FEcGU9Y4zR3XffrY0bN+rVV19VTk5O0P7Ro0fL6XQG5a6pqVFtbW0gt8fj0bvvvhv0jdr2Q9z+F9y55Nprr9W7776rffv2BT7GjBmjmTNnBv47VrOPHz++w1OqP/jgAw0ZMkSSlJOTo4yMjKDsXq9Xu3btCsre2Nio6urqwJhXX31Vra2tGjt2rIUU3dPc3KyEhOB/qnr16qXW1lZJsZ29vXBl9Xg8euONN+T3+wNjKioqdPHFF+v888+3lCZ0bcXjwIEDeuWVV5SWlha0P1az33rrrXrnnXeC/u3LzMzUvHnztHXrVklRmN36Ja4WrV+/3rhcLvPUU0+Z999/39xxxx0mNTU16JkO0eZHP/qRSUlJMa+//ro5dOhQ4KO5uTkw5s477zTZ2dnm1VdfNXv37jUej8d4PJ7A/ranm06ePNns27fPbNmyxVxwwQXn/NNNO3Pys12Mid3su3fvNr179zaPPfaYOXDggHnmmWdMcnKy+c1vfhMYs3TpUpOammp++9vfmnfeecdMmzat06dgXnnllWbXrl1m+/btZtiwYefk001PNmvWLHPhhRcGnmr7wgsvmAEDBpj7778/MCaWsh85csS89dZb5q233jKSzIoVK8xbb70VeEZHOLI2Njaa9PR0c+utt5r9+/eb9evXm+Tk5Ig/3fR02Y8fP26uv/56M3jwYLNv376gf/9OfvZGLGbvTPtnuxgTXdljunwYY8wTTzxhsrOzTZ8+fUxubq7ZuXNnpJfUI5I6/SgrKwuM+etf/2ruuusuc/7555vk5GTz3e9+1xw6dChono8++shMmTLFJCUlmQEDBpgf//jHxu/3W07Tc+3LRyxn37x5sxk5cqRxuVxm+PDh5sknnwza39raahYsWGDS09ONy+Uy1157rampqQka8/nnn5tbbrnF9O3b17jdbjN79mxz5MgRmzFC5vV6zX333Weys7NNYmKi+bu/+zvzk5/8JOgXTixlf+211zr9GZ81a5YxJnxZ3377bTNhwgTjcrnMhRdeaJYuXWor4imdLvvBgwdP+e/fa6+9FpgjFrN3prPyEU3ZHcac9DKBAAAAZ1nMXvMBAADOTZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVv0/zpSarRt+e1IAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGdCAYAAACyzRGfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAsrklEQVR4nO3dfXSU5Z3/8c8EhkkiTCJBEiIJZF0qKPiwIDDCthUDWZYqlhytQi1Fjq41PoR0UdkKBtTy0FOgugFql8b11IiyK7RYhcaoWA7hKYqKdiNu0VhDwvqQDJBmGJPr94e/TJkkQCaZXJOZvF/nzIlz3ddc9/c7ScjHe+6Z22GMMQIAALAkLtIFAACA3oXwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMCqvpEuoLXm5mZVV1drwIABcjgckS4HAAB0gDFGx48fV3p6uuLizn5so8eFj+rqamVkZES6DAAA0AmffPKJhg4detY5PS58DBgwQNLXxbvd7i6v5/f79Yc//EHTpk2T0+ns8nrRhN7pnd57D3qn90j37vV6lZGREfg7fjY9Lny0vNTidrvDFj4SExPldrsj/o2xjd7pnd57D3qn957Se0dOmeCEUwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWNU30gXYNvzB3wfd/2jFjAhVAgBA78SRDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFUhhY+mpiYtXrxYWVlZSkhI0EUXXaRHHnlExpjAHGOMlixZoiFDhighIUHZ2dk6fPhw2AsHAADRKaTwsXLlSq1fv17//u//rj/96U9auXKlVq1apSeeeCIwZ9WqVXr88ce1YcMG7d27V+edd55ycnLU2NgY9uIBAED06RvK5N27d2vmzJmaMePry9APHz5czz77rPbt2yfp66Mea9eu1UMPPaSZM2dKkp5++mmlpqZq69atuvnmm8NcPgAAiDYhhY+rr75aTz75pD744AN94xvf0Ntvv61du3Zp9erVkqQjR46opqZG2dnZgcckJSVpwoQJKi8vbzd8+Hw++Xy+wH2v1ytJ8vv98vv9nWrqdC1rtHx19THtbo9FrXvvTeid3nsbeqf3SAulBoc5/YSNc2hubta//du/adWqVerTp4+ampr02GOPadGiRZK+PjIyadIkVVdXa8iQIYHH3XTTTXI4HHruuefarFlYWKilS5e2GS8pKVFiYmKHGwEAAJHT0NCg2bNnq76+Xm63+6xzQzry8fzzz+uZZ55RSUmJLr30Uh08eFD5+flKT0/X3LlzO1XsokWLVFBQELjv9XqVkZGhadOmnbP4jvD7/SotLdXUqVPldDo1unBH0PZDhTld3kdP1br33oTe6Z3eew967xm9t7xy0REhhY+FCxfqwQcfDLx8MmbMGH388cdavny55s6dq7S0NElSbW1t0JGP2tpaXXHFFe2u6XK55HK52ow7nc6wPpEt6/maHG3GY124n8toQu/03tvQO71HsoaOCundLg0NDYqLC35Inz591NzcLEnKyspSWlqaysrKAtu9Xq/27t0rj8cTyq4AAECMCunIx3XXXafHHntMmZmZuvTSS/XWW29p9erVuu222yRJDodD+fn5evTRRzVixAhlZWVp8eLFSk9P1w033NAd9QMAgCgTUvh44okntHjxYt111106duyY0tPT9S//8i9asmRJYM7999+vkydP6o477lBdXZ0mT56s7du3Kz4+PuzFAwCA6BNS+BgwYIDWrl2rtWvXnnGOw+HQsmXLtGzZsq7WBgAAYhDXdgEAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgVUjhY/jw4XI4HG1ueXl5kqTGxkbl5eUpJSVF/fv3V25urmpra7ulcAAAEJ1CCh/79+/X0aNHA7fS0lJJ0o033ihJWrBggbZt26bNmzdr586dqq6u1qxZs8JfNQAAiFp9Q5l8wQUXBN1fsWKFLrroIn3rW99SfX29Nm7cqJKSEk2ZMkWSVFxcrFGjRmnPnj2aOHFi+KoGAABRK6TwcbpTp07pN7/5jQoKCuRwOFRRUSG/36/s7OzAnJEjRyozM1Pl5eVnDB8+n08+ny9w3+v1SpL8fr/8fn9nywtoWaPlq6uPaXd7LGrde29C7/Te29A7vUdaKDU4jDHm3NPaev755zV79mxVVVUpPT1dJSUlmjdvXlCQkKTx48frmmuu0cqVK9tdp7CwUEuXLm0zXlJSosTExM6UBgAALGtoaNDs2bNVX18vt9t91rmdPvKxceNGTZ8+Xenp6Z1dQpK0aNEiFRQUBO57vV5lZGRo2rRp5yy+I/x+v0pLSzV16lQ5nU6NLtwRtP1QYU6X99FTte69N6F3eqf33oPee0bvLa9cdESnwsfHH3+sV155RS+88EJgLC0tTadOnVJdXZ2Sk5MD47W1tUpLSzvjWi6XSy6Xq8240+kM6xPZsp6vydFmPNaF+7mMJvRO770NvdN7JGvoqE59zkdxcbEGDx6sGTNmBMbGjh0rp9OpsrKywFhlZaWqqqrk8Xg6sxsAABCDQj7y0dzcrOLiYs2dO1d9+/7t4UlJSZo/f74KCgo0cOBAud1u3XPPPfJ4PLzTBQAABIQcPl555RVVVVXptttua7NtzZo1iouLU25urnw+n3JycrRu3bqwFAoAAGJDyOFj2rRpOtMbZOLj41VUVKSioqIuFwYAAGIT13YBAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYFXI4ePTTz/V97//faWkpCghIUFjxozRgQMHAtuNMVqyZImGDBmihIQEZWdn6/Dhw2EtGgAARK+QwseXX36pSZMmyel06uWXX9b777+vn//85zr//PMDc1atWqXHH39cGzZs0N69e3XeeecpJydHjY2NYS8eAABEn76hTF65cqUyMjJUXFwcGMvKygr8tzFGa9eu1UMPPaSZM2dKkp5++mmlpqZq69atuvnmm8NUNgAAiFYhhY/f/e53ysnJ0Y033qidO3fqwgsv1F133aXbb79dknTkyBHV1NQoOzs78JikpCRNmDBB5eXl7YYPn88nn88XuO/1eiVJfr9ffr+/U02drmWNlq+uPqbd7bGode+9Cb3Te29D7/QeaaHU4DDGmHNP+1p8fLwkqaCgQDfeeKP279+v++67Txs2bNDcuXO1e/duTZo0SdXV1RoyZEjgcTfddJMcDoeee+65NmsWFhZq6dKlbcZLSkqUmJjY4UYAAEDkNDQ0aPbs2aqvr5fb7T7r3JDCR79+/TRu3Djt3r07MHbvvfdq//79Ki8v71T4aO/IR0ZGhj777LNzFt8Rfr9fpaWlmjp1qpxOp0YX7gjafqgwp8v76Kla996b0Du903vvQe89o3ev16tBgwZ1KHyE9LLLkCFDdMkllwSNjRo1Sv/93/8tSUpLS5Mk1dbWBoWP2tpaXXHFFe2u6XK55HK52ow7nc6wPpEt6/maHG3GY124n8toQu/03tvQO71HsoaOCundLpMmTVJlZWXQ2AcffKBhw4ZJ+vrk07S0NJWVlQW2e71e7d27Vx6PJ5RdAQCAGBXSkY8FCxbo6quv1k9/+lPddNNN2rdvn5588kk9+eSTkiSHw6H8/Hw9+uijGjFihLKysrR48WKlp6frhhtu6I76AQBAlAkpfFx11VXasmWLFi1apGXLlikrK0tr167VnDlzAnPuv/9+nTx5UnfccYfq6uo0efJkbd++PXCyKgAA6N1CCh+S9J3vfEff+c53zrjd4XBo2bJlWrZsWZcKAwAAsYlruwAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwKqTwUVhYKIfDEXQbOXJkYHtjY6Py8vKUkpKi/v37Kzc3V7W1tWEvGgAARK+Qj3xceumlOnr0aOC2a9euwLYFCxZo27Zt2rx5s3bu3Knq6mrNmjUrrAUDAIDo1jfkB/Ttq7S0tDbj9fX12rhxo0pKSjRlyhRJUnFxsUaNGqU9e/Zo4sSJXa8WAABEvZDDx+HDh5Wenq74+Hh5PB4tX75cmZmZqqiokN/vV3Z2dmDuyJEjlZmZqfLy8jOGD5/PJ5/PF7jv9XolSX6/X36/P9Ty2mhZo+Wrq49pd3ssat17b0Lv9N7b0Du9R1ooNTiMMebc07728ssv68SJE7r44ot19OhRLV26VJ9++qkOHTqkbdu2ad68eUFBQpLGjx+va665RitXrmx3zcLCQi1durTNeElJiRITEzvcCAAAiJyGhgbNnj1b9fX1crvdZ50bUvhora6uTsOGDdPq1auVkJDQqfDR3pGPjIwMffbZZ+csviP8fr9KS0s1depUOZ1OjS7cEbT9UGFOl/fRU7XuvTehd3qn996D3ntG716vV4MGDepQ+Aj5ZZfTJScn6xvf+IY+/PBDTZ06VadOnVJdXZ2Sk5MDc2pra9s9R6SFy+WSy+VqM+50OsP6RLas52tytBmPdeF+LqMJvdN7b0Pv9B7JGjqqS5/zceLECf3v//6vhgwZorFjx8rpdKqsrCywvbKyUlVVVfJ4PF3ZDQAAiCEhHfn413/9V1133XUaNmyYqqur9fDDD6tPnz665ZZblJSUpPnz56ugoEADBw6U2+3WPffcI4/HwztdAABAQEjh4y9/+YtuueUWff7557rgggs0efJk7dmzRxdccIEkac2aNYqLi1Nubq58Pp9ycnK0bt26bikcAABEp5DCx6ZNm866PT4+XkVFRSoqKupSUQAAIHZxbRcAAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWNWl8LFixQo5HA7l5+cHxhobG5WXl6eUlBT1799fubm5qq2t7WqdAAAgRnQ6fOzfv1+//OUvddlllwWNL1iwQNu2bdPmzZu1c+dOVVdXa9asWV0uFAAAxIZOhY8TJ05ozpw5+tWvfqXzzz8/MF5fX6+NGzdq9erVmjJlisaOHavi4mLt3r1be/bsCVvRAAAgenUqfOTl5WnGjBnKzs4OGq+oqJDf7w8aHzlypDIzM1VeXt61SgEAQEzoG+oDNm3apDfffFP79+9vs62mpkb9+vVTcnJy0HhqaqpqamraXc/n88nn8wXue71eSZLf75ff7w+1vDZa1mj56upj2t0ei1r33pvQO733NvRO75EWSg0hhY9PPvlE9913n0pLSxUfHx9yYe1Zvny5li5d2mb8D3/4gxITE8OyD0kqLS2VJK0aHzz+0ksvhW0fPVVL770RvfdO9N470XtkNTQ0dHiuwxhjzj3ta1u3btV3v/td9enTJzDW1NQkh8OhuLg47dixQ9nZ2fryyy+Djn4MGzZM+fn5WrBgQZs12zvykZGRoc8++0xut7vDjZyJ3+9XaWmppk6dKqfTqdGFO4K2HyrM6fI+JLVZt7Nrh2sdqW3vvQm90zu99x703jN693q9GjRokOrr68/59zukIx/XXnut3n333aCxefPmaeTIkXrggQeUkZEhp9OpsrIy5ebmSpIqKytVVVUlj8fT7poul0sul6vNuNPpDOsT2bKer8nRZjwcWq/b2bXDtU7rx0f6hzJS6J3eext6p/dI1tBRIYWPAQMGaPTo0UFj5513nlJSUgLj8+fPV0FBgQYOHCi326177rlHHo9HEydODGVXAAAgRoV8wum5rFmzRnFxccrNzZXP51NOTo7WrVsX7t0AAIAo1eXw8frrrwfdj4+PV1FRkYqKirq6NAAAiEFc2wUAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVoX9cz6izfAHf99m7KMVMyJQCQAAvQNHPgAAgFWEDwAAYBXhAwAAWNXrz/loT3vngbTWmfNCOL8EAACOfAAAAMsIHwAAwCrCBwAAsIrwAQAArOKE016u9UmwnAALAOhuHPkAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBWf8xEFOvJZHO1dtO7wI9O6rSYAADqLIx8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArAopfKxfv16XXXaZ3G633G63PB6PXn755cD2xsZG5eXlKSUlRf3791dubq5qa2vDXnRvN/zB37e5tWd04Y7A1zPNAQDAtpDCx9ChQ7VixQpVVFTowIEDmjJlimbOnKn33ntPkrRgwQJt27ZNmzdv1s6dO1VdXa1Zs2Z1S+EAACA6hfQJp9ddd13Q/ccee0zr16/Xnj17NHToUG3cuFElJSWaMmWKJKm4uFijRo3Snj17NHHixPBVDQAAolanz/loamrSpk2bdPLkSXk8HlVUVMjv9ys7OzswZ+TIkcrMzFR5eXlYigUAANEv5Gu7vPvuu/J4PGpsbFT//v21ZcsWXXLJJTp48KD69eun5OTkoPmpqamqqak543o+n08+ny9w3+v1SpL8fr/8fn+o5bXRskbLV1cf0+U1T1+vRXvrhmtOZ7niTNDX9p7P1vsLx3PeE7T+vvcm9E7vvQ2994zeQ6nBYYwJ6a/dqVOnVFVVpfr6ev3Xf/2X/uM//kM7d+7UwYMHNW/evKAgIUnjx4/XNddco5UrV7a7XmFhoZYuXdpmvKSkRImJiaGUBgAAIqShoUGzZ89WfX293G73WeeGHD5ay87O1kUXXaTvfe97uvbaa/Xll18GHf0YNmyY8vPztWDBgnYf396Rj4yMDH322WfnLL4j/H6/SktLNXXqVDmdzsA7QLrqUGFO0P321g3XnM5yxRk9Mq5Ziw/EydfsaLOv9vbX3pxo1Pr73pvQO73Te+/Rk3r3er0aNGhQh8JHyC+7tNbc3Cyfz6exY8fK6XSqrKxMubm5kqTKykpVVVXJ4/Gc8fEul0sul6vNuNPpDOsT2bKer8kRtvVO19664ZrTVb5mh3xNjnafz9b7i/QPb7iF++comtA7vfc29B7Z3kPZf0jhY9GiRZo+fboyMzN1/PhxlZSU6PXXX9eOHTuUlJSk+fPnq6CgQAMHDpTb7dY999wjj8fDO10AAEBASOHj2LFj+sEPfqCjR48qKSlJl112mXbs2KGpU6dKktasWaO4uDjl5ubK5/MpJydH69at65bCAQBAdAopfGzcuPGs2+Pj41VUVKSioqIuFQUAAGIX13YBAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVV2+qi3ObPiDv490CUE6Uk97cz5aMaM7ygEA9FIc+QAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFjFheUQFq0vSMfF6AAAZ8KRDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWhRQ+li9frquuukoDBgzQ4MGDdcMNN6iysjJoTmNjo/Ly8pSSkqL+/fsrNzdXtbW1YS0aAABEr5DCx86dO5WXl6c9e/aotLRUfr9f06ZN08mTJwNzFixYoG3btmnz5s3auXOnqqurNWvWrLAXDgAAolNIn3C6ffv2oPtPPfWUBg8erIqKCn3zm99UfX29Nm7cqJKSEk2ZMkWSVFxcrFGjRmnPnj2aOHFi+CoHAABRqUsfr15fXy9JGjhwoCSpoqJCfr9f2dnZgTkjR45UZmamysvL2w0fPp9PPp8vcN/r9UqS/H6//H5/V8oLrHP6V1cf0+U1T1+vRWfXDdc67XHFmaCvndWR70PrusPxveuK1t/33oTe6b23ofee0XsoNTiMMZ36y9Tc3Kzrr79edXV12rVrlySppKRE8+bNCwoTkjR+/Hhdc801WrlyZZt1CgsLtXTp0jbjJSUlSkxM7ExpAADAsoaGBs2ePVv19fVyu91nndvpIx95eXk6dOhQIHh01qJFi1RQUBC47/V6lZGRoWnTpp2z+I7w+/0qLS3V1KlT5XQ6NbpwR5fXDKdDhTlB98NZnyvO6JFxzVp8IE6+Zken12ldY3ta192Rx3Sn1t/33oTe6Z3ee4+e1HvLKxcd0anwcffdd+vFF1/UG2+8oaFDhwbG09LSdOrUKdXV1Sk5OTkwXltbq7S0tHbXcrlccrlcbcadTmdYn8iW9XxNnf8j3B1a99gd9fmaHV1atyPfh9brR/qXoEW4f46iCb3Te29D75HtPZT9h/RuF2OM7r77bm3ZskWvvvqqsrKygraPHTtWTqdTZWVlgbHKykpVVVXJ4/GEsisAABCjQjrykZeXp5KSEv32t7/VgAEDVFNTI0lKSkpSQkKCkpKSNH/+fBUUFGjgwIFyu92655575PF4eKcLAACQFGL4WL9+vSTp29/+dtB4cXGxfvjDH0qS1qxZo7i4OOXm5srn8yknJ0fr1q0LS7HoGYY/+PtIlwAAiGIhhY+OvDEmPj5eRUVFKioq6nRRAAAgdnFtFwAAYBXhAwAAWNWlTzgFzqS980I+WjEjApUAAHoajnwAAACrCB8AAMAqwgcAALCKcz4QMZwXAgC9E0c+AACAVYQPAABgFeEDAABYxTkfEcZ1UgAAvQ1HPgAAgFWEDwAAYBXhAwAAWMU5H+jR+CwQAIg9HPkAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWMWHjOGcwnXxOy6iBwCQOPIBAAAsI3wAAACrCB8AAMAqzvlAj8J5IQAQ+zjyAQAArCJ8AAAAqwgfAADAqpDDxxtvvKHrrrtO6enpcjgc2rp1a9B2Y4yWLFmiIUOGKCEhQdnZ2Tp8+HC46gU0/MHfB90AANEl5PBx8uRJXX755SoqKmp3+6pVq/T4449rw4YN2rt3r8477zzl5OSosbGxy8UCAIDoF/K7XaZPn67p06e3u80Yo7Vr1+qhhx7SzJkzJUlPP/20UlNTtXXrVt18881dqxYAAES9sL7V9siRI6qpqVF2dnZgLCkpSRMmTFB5eXm74cPn88nn8wXue71eSZLf75ff7+9yTS1rtHx19TFdXjNauOJM0NdY1d7PSevve29C7/Te29B7z+g9lBocxphO/2VyOBzasmWLbrjhBknS7t27NWnSJFVXV2vIkCGBeTfddJMcDoeee+65NmsUFhZq6dKlbcZLSkqUmJjY2dIAAIBFDQ0Nmj17turr6+V2u886N+IfMrZo0SIVFBQE7nu9XmVkZGjatGnnLL4j/H6/SktLNXXqVDmdTo0u3NHlNaOFK87okXHNWnwgTr5mR6TL6TaHCnPajLX+vren9c9Ce+tEo470Hqvond7pPXJaXrnoiLCGj7S0NElSbW1t0JGP2tpaXXHFFe0+xuVyyeVytRl3Op1hfSJb1vM1xe4f4TPxNTtiuu+z/Zyc7eeo9XMS6V/ccAv371A0oXd67216Qu+h7D+sn/ORlZWltLQ0lZWVBca8Xq/27t0rj8cTzl0BAIAoFfKRjxMnTujDDz8M3D9y5IgOHjyogQMHKjMzU/n5+Xr00Uc1YsQIZWVlafHixUpPTw+cFwIAAHq3kMPHgQMHdM011wTut5yvMXfuXD311FO6//77dfLkSd1xxx2qq6vT5MmTtX37dsXHx4evagAAELVCDh/f/va3dbY3yDgcDi1btkzLli3rUmEAACA2cW0XAABgFeEDAABYFfHP+QCiSXsXsvtoxYwIVAIA0YsjHwAAwCrCBwAAsIrwAQAArOKcD/QK7Z2r0V1rt3cOSEfmAEBvwZEPAABgFeEDAABYRfgAAABWcc4Hol5753O4+hitGi+NLtwhX5MjrGv3dKMLdwT1zvklAHoajnwAAACrCB8AAMAqwgcAALCKcz6AMOvIeSKdvUZMZz4vhOvRAOhpOPIBAACsInwAAACrCB8AAMAqwgcAALCKE06BHirSF8MDgO7CkQ8AAGAV4QMAAFhF+AAAAFZxzgfQQ0TjRew6gg9GA9AaRz4AAIBVhA8AAGAV4QMAAFjFOR/A/xer51x0VkfO1QjXc8Zz/ze2z3fhM19iX088h4ojHwAAwCrCBwAAsIrwAQAArOq2cz6Kior0s5/9TDU1Nbr88sv1xBNPaPz48d21O6BXau+1XFef8KzTmTndqSP7P/zItHM+pjOfM9KR81268/NLwvWafWe/z+HaV6TPM+gMzonpHt1y5OO5555TQUGBHn74Yb355pu6/PLLlZOTo2PHjnXH7gAAQBTplvCxevVq3X777Zo3b54uueQSbdiwQYmJifr1r3/dHbsDAABRJOwvu5w6dUoVFRVatGhRYCwuLk7Z2dkqLy9vM9/n88nn8wXu19fXS5K++OIL+f3+Ltfj9/vV0NCgzz//XE6nU32/OtnlNaNF32ajhoZm9fXHqanZEelyrKL3ntv7559/3mYsXL+Xn3/++Tl/39vb/7nq6UjNnVm3vcd19Llo/bjW/9Z1dP+d2VdHdPa574yO9N5Znfk+29TZ73t39HH8+HFJkjHm3JNNmH366adGktm9e3fQ+MKFC8348ePbzH/44YeNJG7cuHHjxo1bDNw++eSTc2aFiH/I2KJFi1RQUBC439zcrC+++EIpKSlyOLr+f21er1cZGRn65JNP5Ha7u7xeNKF3eqf33oPe6T3SvRtjdPz4caWnp59zbtjDx6BBg9SnTx/V1tYGjdfW1iotLa3NfJfLJZfLFTSWnJwc7rLkdrsj/o2JFHqn996G3um9t+kpvSclJXVoXthPOO3Xr5/Gjh2rsrKywFhzc7PKysrk8XjCvTsAABBluuVll4KCAs2dO1fjxo3T+PHjtXbtWp08eVLz5s3rjt0BAIAo0i3h43vf+57+7//+T0uWLFFNTY2uuOIKbd++Xampqd2xu7NyuVx6+OGH27y00xvQO733NvRO771NtPbuMKYj74kBAAAID67tAgAArCJ8AAAAqwgfAADAKsIHAACwKubDR1FRkYYPH674+HhNmDBB+/bti3RJXbJ8+XJdddVVGjBggAYPHqwbbrhBlZWVQXMaGxuVl5enlJQU9e/fX7m5uW0+9K2qqkozZsxQYmKiBg8erIULF+qrr76y2UqXrVixQg6HQ/n5+YGxWO79008/1fe//32lpKQoISFBY8aM0YEDBwLbjTFasmSJhgwZooSEBGVnZ+vw4cNBa3zxxReaM2eO3G63kpOTNX/+fJ04ccJ2KyFpamrS4sWLlZWVpYSEBF100UV65JFHgq4fESu9v/HGG7ruuuuUnp4uh8OhrVu3Bm0PV5/vvPOO/vEf/1Hx8fHKyMjQqlWruru1czpb736/Xw888IDGjBmj8847T+np6frBD36g6urqoDVisffW7rzzTjkcDq1duzZoPOp67/rVXHquTZs2mX79+plf//rX5r333jO33367SU5ONrW1tZEurdNycnJMcXGxOXTokDl48KD553/+Z5OZmWlOnDgRmHPnnXeajIwMU1ZWZg4cOGAmTpxorr766sD2r776yowePdpkZ2ebt956y7z00ktm0KBBZtGiRZFoqVP27dtnhg8fbi677DJz3333BcZjtfcvvvjCDBs2zPzwhz80e/fuNX/+85/Njh07zIcffhiYs2LFCpOUlGS2bt1q3n77bXP99debrKws89e//jUw55/+6Z/M5Zdfbvbs2WP++Mc/mr//+783t9xySyRa6rDHHnvMpKSkmBdffNEcOXLEbN682fTv39/84he/CMyJld5feukl85Of/MS88MILRpLZsmVL0PZw9FlfX29SU1PNnDlzzKFDh8yzzz5rEhISzC9/+UtbbbbrbL3X1dWZ7Oxs89xzz5n/+Z//MeXl5Wb8+PFm7NixQWvEYu+ne+GFF8zll19u0tPTzZo1a4K2RVvvMR0+xo8fb/Ly8gL3m5qaTHp6ulm+fHkEqwqvY8eOGUlm586dxpivf0mdTqfZvHlzYM6f/vQnI8mUl5cbY77+QY+LizM1NTWBOevXrzdut9v4fD67DXTC8ePHzYgRI0xpaan51re+FQgfsdz7Aw88YCZPnnzG7c3NzSYtLc387Gc/C4zV1dUZl8tlnn32WWOMMe+//76RZPbv3x+Y8/LLLxuHw2E+/fTT7iu+i2bMmGFuu+22oLFZs2aZOXPmGGNit/fWf4TC1ee6devM+eefH/Tz/sADD5iLL764mzvquLP9AW6xb98+I8l8/PHHxpjY7/0vf/mLufDCC82hQ4fMsGHDgsJHNPYesy+7nDp1ShUVFcrOzg6MxcXFKTs7W+Xl5RGsLLzq6+slSQMHDpQkVVRUyO/3B/U9cuRIZWZmBvouLy/XmDFjgj70LScnR16vV++9957F6jsnLy9PM2bMCOpRiu3ef/e732ncuHG68cYbNXjwYF155ZX61a9+Fdh+5MgR1dTUBPWelJSkCRMmBPWenJyscePGBeZkZ2crLi5Oe/futddMiK6++mqVlZXpgw8+kCS9/fbb2rVrl6ZPny4ptns/Xbj6LC8v1ze/+U3169cvMCcnJ0eVlZX68ssvLXXTdfX19XI4HIFrgcVy783Nzbr11lu1cOFCXXrppW22R2PvMRs+PvvsMzU1NbX5VNXU1FTV1NREqKrwam5uVn5+viZNmqTRo0dLkmpqatSvX782F+c7ve+ampp2n5eWbT3Zpk2b9Oabb2r58uVttsVy73/+85+1fv16jRgxQjt27NCPfvQj3XvvvfrP//xPSX+r/Ww/7zU1NRo8eHDQ9r59+2rgwIE9uvcHH3xQN998s0aOHCmn06krr7xS+fn5mjNnjqTY7v104eozWn8HTtfY2KgHHnhAt9xyS+BiarHc+8qVK9W3b1/de++97W6Pxt675ePVYUdeXp4OHTqkXbt2RboUKz755BPdd999Ki0tVXx8fKTLsaq5uVnjxo3TT3/6U0nSlVdeqUOHDmnDhg2aO3duhKvrXs8//7yeeeYZlZSU6NJLL9XBgweVn5+v9PT0mO8dbfn9ft10000yxmj9+vWRLqfbVVRU6Be/+IXefPNNORyOSJcTNjF75GPQoEHq06dPm3c61NbWKi0tLUJVhc/dd9+tF198Ua+99pqGDh0aGE9LS9OpU6dUV1cXNP/0vtPS0tp9Xlq29VQVFRU6duyY/uEf/kF9+/ZV3759tXPnTj3++OPq27evUlNTY7b3IUOG6JJLLgkaGzVqlKqqqiT9rfaz/bynpaXp2LFjQdu/+uorffHFFz2694ULFwaOfowZM0a33nqrFixYEDj6Fcu9ny5cfUbr74D0t+Dx8ccfq7S0NOgS8rHa+x//+EcdO3ZMmZmZgX/3Pv74Y/34xz/W8OHDJUVn7zEbPvr166exY8eqrKwsMNbc3KyysjJ5PJ4IVtY1xhjdfffd2rJli1599VVlZWUFbR87dqycTmdQ35WVlaqqqgr07fF49O677wb9sLb8Irf+A9eTXHvttXr33Xd18ODBwG3cuHGaM2dO4L9jtfdJkya1eUv1Bx98oGHDhkmSsrKylJaWFtS71+vV3r17g3qvq6tTRUVFYM6rr76q5uZmTZgwwUIXndPQ0KC4uOB/qvr06aPm5mZJsd376cLVp8fj0RtvvCG/3x+YU1paqosvvljnn3++pW5C1xI8Dh8+rFdeeUUpKSlB22O191tvvVXvvPNO0L976enpWrhwoXbs2CEpSnuPyGmulmzatMm4XC7z1FNPmffff9/ccccdJjk5OeidDtHmRz/6kUlKSjKvv/66OXr0aODW0NAQmHPnnXeazMxM8+qrr5oDBw4Yj8djPB5PYHvL202nTZtmDh48aLZv324uuOCCHv920/ac/m4XY2K393379pm+ffuaxx57zBw+fNg888wzJjEx0fzmN78JzFmxYoVJTk42v/3tb80777xjZs6c2e7bMK+88kqzd+9es2vXLjNixIge93bT1ubOnWsuvPDCwFttX3jhBTNo0CBz//33B+bESu/Hjx83b731lnnrrbeMJLN69Wrz1ltvBd7REY4+6+rqTGpqqrn11lvNoUOHzKZNm0xiYmLE3256tt5PnTplrr/+ejN06FBz8ODBoH/7Tn/3Riz23p7W73YxJvp6j+nwYYwxTzzxhMnMzDT9+vUz48ePN3v27Il0SV0iqd1bcXFxYM5f//pXc9ddd5nzzz/fJCYmmu9+97vm6NGjQet89NFHZvr06SYhIcEMGjTI/PjHPzZ+v99yN13XOnzEcu/btm0zo0ePNi6Xy4wcOdI8+eSTQdubm5vN4sWLTWpqqnG5XObaa681lZWVQXM+//xzc8stt5j+/fsbt9tt5s2bZ44fP26zjZB5vV5z3333mczMTBMfH2/+7u/+zvzkJz8J+qMTK72/9tpr7f5+z5071xgTvj7ffvttM3nyZONyucyFF15oVqxYYavFMzpb70eOHDnjv32vvfZaYI1Y7L097YWPaOvdYcxpHxMIAADQzWL2nA8AANAzET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABY9f8AuhqgSI7rVfYAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -3163,7 +3479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 56,
    "id": "8b595e14",
    "metadata": {},
    "outputs": [
@@ -3172,16 +3488,16 @@
       "text/plain": [
        "count     857.000000\n",
        "mean      221.512252\n",
-       "std       199.989439\n",
+       "std       200.005906\n",
        "min         9.000000\n",
        "25%        82.000000\n",
        "50%       176.000000\n",
        "75%       299.000000\n",
-       "max      1438.000000\n",
+       "max      1440.000000\n",
        "Name: address_id, dtype: float64"
       ]
      },
-     "execution_count": 120,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3192,7 +3508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 57,
    "id": "b5cb333d",
    "metadata": {},
    "outputs": [
@@ -3202,13 +3518,324 @@
        "9.283387940730599"
       ]
      },
-     "execution_count": 121,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df_census.address_id.nunique() / len(address_to_zip)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0559c4f",
+   "metadata": {},
+   "source": [
+    "# Join zipcodes onto WIC data and check distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "480db8e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>address_id</th>\n",
+       "      <th>index_of_orig_address</th>\n",
+       "      <th>orig_address</th>\n",
+       "      <th>zipcode</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>35</td>\n",
+       "      <td>35</td>\n",
+       "      <td>420th ave  bradenton, fl</td>\n",
+       "      <td>34205</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>53</td>\n",
+       "      <td>53</td>\n",
+       "      <td>8th st  melbourne, fl</td>\n",
+       "      <td>32940</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>88</td>\n",
+       "      <td>88</td>\n",
+       "      <td>belvedere avenue south west  south daytona, fl</td>\n",
+       "      <td>32119</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>97912</td>\n",
+       "      <td>16116</td>\n",
+       "      <td>5911 chestnut st  st. petersburg, fl</td>\n",
+       "      <td>33710</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>109</td>\n",
+       "      <td>109</td>\n",
+       "      <td>broad  jupiter, fl</td>\n",
+       "      <td>33458</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>593011</th>\n",
+       "      <td>152642</td>\n",
+       "      <td>9499</td>\n",
+       "      <td>26 putnam road  jacksonville, fl</td>\n",
+       "      <td>32258</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>593012</th>\n",
+       "      <td>135561</td>\n",
+       "      <td>12867</td>\n",
+       "      <td>40 putnam circle northeast apt no 101 vero bea...</td>\n",
+       "      <td>32960</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>593013</th>\n",
+       "      <td>167694</td>\n",
+       "      <td>4102</td>\n",
+       "      <td>1360 cable rd  boynton beach, fl</td>\n",
+       "      <td>33426</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>593014</th>\n",
+       "      <td>97484</td>\n",
+       "      <td>15688</td>\n",
+       "      <td>5554 n pinebay cir  port richey, fl</td>\n",
+       "      <td>34668</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>593015</th>\n",
+       "      <td>182110</td>\n",
+       "      <td>18518</td>\n",
+       "      <td>7912 cecilia st  lake mary, fl</td>\n",
+       "      <td>32746</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>593016 rows × 4 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        address_id  index_of_orig_address  \\\n",
+       "0               35                     35   \n",
+       "1               53                     53   \n",
+       "2               88                     88   \n",
+       "3            97912                  16116   \n",
+       "4              109                    109   \n",
+       "...            ...                    ...   \n",
+       "593011      152642                   9499   \n",
+       "593012      135561                  12867   \n",
+       "593013      167694                   4102   \n",
+       "593014       97484                  15688   \n",
+       "593015      182110                  18518   \n",
+       "\n",
+       "                                             orig_address zipcode  \n",
+       "0                                420th ave  bradenton, fl   34205  \n",
+       "1                                   8th st  melbourne, fl   32940  \n",
+       "2          belvedere avenue south west  south daytona, fl   32119  \n",
+       "3                    5911 chestnut st  st. petersburg, fl   33710  \n",
+       "4                                      broad  jupiter, fl   33458  \n",
+       "...                                                   ...     ...  \n",
+       "593011                   26 putnam road  jacksonville, fl   32258  \n",
+       "593012  40 putnam circle northeast apt no 101 vero bea...   32960  \n",
+       "593013                   1360 cable rd  boynton beach, fl   33426  \n",
+       "593014                5554 n pinebay cir  port richey, fl   34668  \n",
+       "593015                     7912 cecilia st  lake mary, fl   32746  \n",
+       "\n",
+       "[593016 rows x 4 columns]"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wic_zips = df_wic[['address_id']].join(address_id_to_zip, on='address_id')\n",
+    "wic_zips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "6c194923",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "zipcode\n",
+       "32003    214\n",
+       "32008     29\n",
+       "32009     10\n",
+       "32011     60\n",
+       "32024      4\n",
+       "        ... \n",
+       "34987     43\n",
+       "34990    177\n",
+       "34994     96\n",
+       "34996     99\n",
+       "34997    175\n",
+       "Name: address_id, Length: 857, dtype: int64"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wic_addresses_per_zip = wic_zips.groupby('zipcode')['address_id'].nunique()\n",
+    "wic_addresses_per_zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "18d32e6e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7      17\n",
+       "5      11\n",
+       "12     11\n",
+       "6      10\n",
+       "99      9\n",
+       "       ..\n",
+       "311     1\n",
+       "461     1\n",
+       "372     1\n",
+       "312     1\n",
+       "177     1\n",
+       "Name: address_id, Length: 330, dtype: int64"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wic_addresses_per_zip.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "e44b6382",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot: >"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGdCAYAAACyzRGfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAm3klEQVR4nO3dfXBU133G8WeFVivJsJIRhoUggZq4EQ5+IWBgjaeJsV5KiGMXjR0b0mLC2JNGJoBaO6gNtiAmYHdqHLcC6gyRJ5OouLQxCX4BK6KWyyDxIpfU2K2MG1xRhJbaVFpAYblGp39k2LJIgHbZPReJ72dmJ95zz977298V8OTu2SuPMcYIAADAkjS3CwAAANcWwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAq9LdLuBCPT09am9v17Bhw+TxeNwuBwAA9IMxRidOnNCYMWOUlnbpaxtXXfhob29Xfn6+22UAAIAEHD58WGPHjr3knKsufAwbNkzS74r3+/1J2afjOHrzzTdVWloqr9eblH0iPpwDd9F/d9F/d9F/O8LhsPLz86P/jl/KVRc+zn3U4vf7kxo+srOz5ff7+cFzCefAXfTfXfTfXfTfrv4smWDBKQAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwKq7wMX78eHk8nl6PiooKSdLp06dVUVGhvLw8DR06VOXl5QqFQikpHAAADExxhY+9e/fq6NGj0Ud9fb0k6f7775ckLV26VFu3btXmzZvV2Nio9vZ2zZkzJ/lVAwCAASuu+3zccMMNMc/XrFmjz372s/rSl76krq4ubdy4UXV1dZo5c6Ykqba2VhMmTFBzc7OmT5+evKoBAMCAlfBNxs6cOaOf/vSnqqyslMfjUUtLixzHUXFxcXROUVGRCgoK1NTUdNHwEYlEFIlEos/D4bCk390UxnGcRMuLcW4/ydof4sc5cBf9dxf9dxf9tyOe/iYcPrZs2aLOzk49/PDDkqSOjg5lZGQoNzc3Zt6oUaPU0dFx0f2sXr1aK1as6DX+5ptvKjs7O9Hy+nTuYyK4h3PgLvrvLvrvLvqfWt3d3f2em3D42Lhxo2bNmqUxY8YkugtJUlVVlSorK6PPz90bvrS0NKm3V6+vr1dJSQm31nUJ58Bd9N9d9N9d9N+Oc59c9EdC4eO//uu/9Ktf/Uo///nPo2OBQEBnzpxRZ2dnzNWPUCikQCBw0X35fD75fL5e416vN+k/JKnYJ+LDOXAX/XcX/XcX/U+teHqb0H0+amtrNXLkSM2ePTs6NnnyZHm9XjU0NETHWltb1dbWpmAwmMhhAADAIBT3lY+enh7V1tZq/vz5Sk///5fn5ORo4cKFqqys1PDhw+X3+7Vo0SIFg0G+6QIAAKLiDh+/+tWv1NbWpm9+85u9tq1du1ZpaWkqLy9XJBJRWVmZ1q1bl5RCk2X8stdinn+0ZvZFZgIAgFSIO3yUlpbKGNPntszMTNXU1KimpuaKCwMAAIMTv9sFAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGBV3OHjyJEj+sY3vqG8vDxlZWXp5ptv1r59+6LbjTF68sknNXr0aGVlZam4uFgHDx5MatEAAGDgiit8/O///q9mzJghr9erN954Q++//77++q//Wtdff310zrPPPqsXXnhBGzZs0O7du3XdddeprKxMp0+fTnrxAABg4EmPZ/Izzzyj/Px81dbWRscKCwuj/22M0fPPP6/vfe97uvfeeyVJP/nJTzRq1Cht2bJFDz74YJLKBgAAA1Vc4eOXv/ylysrKdP/996uxsVGf+cxn9O1vf1uPPPKIJOnQoUPq6OhQcXFx9DU5OTmaNm2ampqa+gwfkUhEkUgk+jwcDkuSHMeR4zgJvakLnduP4zjyDTF9bkNqnX8OYB/9dxf9dxf9tyOe/nqMMeby034nMzNTklRZWan7779fe/fu1eLFi7VhwwbNnz9fu3bt0owZM9Te3q7Ro0dHX/fAAw/I4/Ho5Zdf7rXP6upqrVixotd4XV2dsrOz+/1GAACAe7q7uzV37lx1dXXJ7/dfcm5c4SMjI0NTpkzRrl27omPf+c53tHfvXjU1NSUUPvq68pGfn6+PP/74ssX3l+M4qq+vV0lJiSat2hGz7UB1WVKOgUs7/xx4vV63y7nm0H930X930X87wuGwRowY0a/wEdfHLqNHj9ZNN90UMzZhwgT90z/9kyQpEAhIkkKhUEz4CIVCuu222/rcp8/nk8/n6zXu9XqT/kPi9XoVOevpNQZ7UnFe0X/031303130P7Xi6W1c33aZMWOGWltbY8Y++OADjRs3TtLvFp8GAgE1NDREt4fDYe3evVvBYDCeQwEAgEEqrisfS5cu1R133KEf/OAHeuCBB7Rnzx69+OKLevHFFyVJHo9HS5Ys0dNPP60bb7xRhYWFWr58ucaMGaP77rsvFfUDAIABJq7wcfvtt+uVV15RVVWVVq5cqcLCQj3//POaN29edM4TTzyhU6dO6dFHH1VnZ6fuvPNObdu2LbpYFQAAXNviCh+S9NWvflVf/epXL7rd4/Fo5cqVWrly5RUVBgAABid+twsAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwKq4wkd1dbU8Hk/Mo6ioKLr99OnTqqioUF5enoYOHary8nKFQqGkFw0AAAauuK98fOELX9DRo0ejj507d0a3LV26VFu3btXmzZvV2Nio9vZ2zZkzJ6kFAwCAgS097hekpysQCPQa7+rq0saNG1VXV6eZM2dKkmprazVhwgQ1Nzdr+vTpV14tAAAY8OIOHwcPHtSYMWOUmZmpYDCo1atXq6CgQC0tLXIcR8XFxdG5RUVFKigoUFNT00XDRyQSUSQSiT4Ph8OSJMdx5DhOvOX16dx+HMeRb4jpcxtS6/xzAPvov7vov7vovx3x9NdjjDGXn/Y7b7zxhk6ePKnPf/7zOnr0qFasWKEjR47owIED2rp1qxYsWBATJCRp6tSpuuuuu/TMM8/0uc/q6mqtWLGi13hdXZ2ys7P7/UYAAIB7uru7NXfuXHV1dcnv919yblzh40KdnZ0aN26cnnvuOWVlZSUUPvq68pGfn6+PP/74ssX3l+M4qq+vV0lJiSat2hGz7UB1WVKOgUs7/xx4vV63y7nm0H930X930X87wuGwRowY0a/wEffHLufLzc3V7//+7+vDDz9USUmJzpw5o87OTuXm5kbnhEKhPteInOPz+eTz+XqNe73epP+QeL1eRc56eo3BnlScV/Qf/XcX/XcX/U+teHp7Rff5OHnypP7zP/9To0eP1uTJk+X1etXQ0BDd3traqra2NgWDwSs5DAAAGETiuvLx53/+57rnnns0btw4tbe366mnntKQIUP00EMPKScnRwsXLlRlZaWGDx8uv9+vRYsWKRgM8k0XAAAQFVf4+O///m899NBD+uSTT3TDDTfozjvvVHNzs2644QZJ0tq1a5WWlqby8nJFIhGVlZVp3bp1KSkcAAAMTHGFj02bNl1ye2ZmpmpqalRTU3NFRQEAgMGL3+0CAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAq9LdLsBt45e91mvsozWzXagEAIBrA1c+AACAVYQPAABgFeEDAABYRfgAAABWXfMLTvty4SJUtxegXm31AABwJa7oyseaNWvk8Xi0ZMmS6Njp06dVUVGhvLw8DR06VOXl5QqFQldaJwAAGCQSDh979+7V3/3d3+mWW26JGV+6dKm2bt2qzZs3q7GxUe3t7ZozZ84VFwoAAAaHhMLHyZMnNW/ePP3oRz/S9ddfHx3v6urSxo0b9dxzz2nmzJmaPHmyamtrtWvXLjU3NyetaAAAMHAltOajoqJCs2fPVnFxsZ5++unoeEtLixzHUXFxcXSsqKhIBQUFampq0vTp03vtKxKJKBKJRJ+Hw2FJkuM4chwnkfJ6Obcfx3HkG2ISfr1bLqzZ7XoScf45gH30313031303454+ht3+Ni0aZPeeecd7d27t9e2jo4OZWRkKDc3N2Z81KhR6ujo6HN/q1ev1ooVK3qNv/nmm8rOzo63vEuqr6/Xs1Pjf93rr7+e1DridWHNbtdzJerr690u4ZpG/91F/91F/1Oru7u733PjCh+HDx/W4sWLVV9fr8zMzLgL60tVVZUqKyujz8PhsPLz81VaWiq/35+UYziOo/r6epWUlGjSqh1xv/5AdVlS6kjUxOrtMc/dricR558Dr9frdjnXHPrvLvrvLvpvx7lPLvojrvDR0tKiY8eO6Ytf/GJ07OzZs3r77bf1t3/7t9q+fbvOnDmjzs7OmKsfoVBIgUCgz336fD75fL5e416vN+k/JF6vV5GznoRe56YLa3a7niuRivOK/qP/7qL/7qL/qRVPb+MKH3fffbfefffdmLEFCxaoqKhI3/3ud5Wfny+v16uGhgaVl5dLklpbW9XW1qZgMBjPoQAAwCAVV/gYNmyYJk6cGDN23XXXKS8vLzq+cOFCVVZWavjw4fL7/Vq0aJGCwWCfi00BAMC1J+l3OF27dq3S0tJUXl6uSCSisrIyrVu3LtmHAQAAA9QVh4+33nor5nlmZqZqampUU1NzpbsGAACDEL9YDgAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBV6W4XgFjjl73mdgkAAKQUVz4AAIBVhA8AAGAV4QMAAFhF+AAAAFax4HQQu3Dx6kdrZrtUCQAA/48rHwAAwCrCBwAAsIrwAQAArCJ8AAAAq1hwalFfdy9lESgA4FrDlQ8AAGAV4QMAAFhF+AAAAFYRPgAAgFUsOE3QYL17KItiAQCpxpUPAABgFeEDAABYRfgAAABWET4AAIBVLDhNob4WbwIAcK2L68rH+vXrdcstt8jv98vv9ysYDOqNN96Ibj99+rQqKiqUl5enoUOHqry8XKFQKOlFAwCAgSuu8DF27FitWbNGLS0t2rdvn2bOnKl7771X7733niRp6dKl2rp1qzZv3qzGxka1t7drzpw5KSkcAAAMTHF97HLPPffEPF+1apXWr1+v5uZmjR07Vhs3blRdXZ1mzpwpSaqtrdWECRPU3Nys6dOnJ69qAAAwYCW85uPs2bPavHmzTp06pWAwqJaWFjmOo+Li4uicoqIiFRQUqKmp6aLhIxKJKBKJRJ+Hw2FJkuM4chwn0fJinNuP4zjyDTEJv/58F+6nP3P6s+9EXnMx/anxcq+J53iXcv45gH30313031303454+usxxsT1r/G7776rYDCo06dPa+jQoaqrq9NXvvIV1dXVacGCBTFBQpKmTp2qu+66S88880yf+6uurtaKFSt6jdfV1Sk7Ozue0gAAgEu6u7s1d+5cdXV1ye/3X3Ju3Fc+Pv/5z2v//v3q6urSP/7jP2r+/PlqbGxMuNiqqipVVlZGn4fDYeXn56u0tPSyxfeX4ziqr69XSUmJJq3aEffrD1SX9RqbWL097jn92Xcir7mYZB2/v8e7lPPPgdfrveL9IT7031303130345zn1z0R9zhIyMjQ5/73OckSZMnT9bevXv1wx/+UF//+td15swZdXZ2Kjc3Nzo/FAopEAhcdH8+n08+n6/XuNfrTfoPidfrVeSsJ6HXXejC/fRnTn/2nchrLiZZx0/meUjFeUX/0X930X930f/Uiqe3V3yTsZ6eHkUiEU2ePFler1cNDQ3Rba2trWpra1MwGLzSwwAAgEEirisfVVVVmjVrlgoKCnTixAnV1dXprbfe0vbt25WTk6OFCxeqsrJSw4cPl9/v16JFixQMBvmmCwAAiIorfBw7dkx/8id/oqNHjyonJ0e33HKLtm/frpKSEknS2rVrlZaWpvLyckUiEZWVlWndunUpKdymwXyn0sH83gAAV6e4wsfGjRsvuT0zM1M1NTWqqam5oqIAAMDgxS+WAwAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFbF/Vtt0TduUw4AQP9w5QMAAFhF+AAAAFYRPgAAgFWEDwAAYBULTl2WrIWqLHgFAAwUXPkAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYFW62wUgfuOXveZ2Cb1cWNNHa2a7VAkA4GrHlQ8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYFVc4WP16tW6/fbbNWzYMI0cOVL33XefWltbY+acPn1aFRUVysvL09ChQ1VeXq5QKJTUogEAwMAVV/hobGxURUWFmpubVV9fL8dxVFpaqlOnTkXnLF26VFu3btXmzZvV2Nio9vZ2zZkzJ+mFAwCAgSmu+3xs27Yt5vlLL72kkSNHqqWlRX/wB3+grq4ubdy4UXV1dZo5c6Ykqba2VhMmTFBzc7OmT5+evMoBAMCAdEU3Gevq6pIkDR8+XJLU0tIix3FUXFwcnVNUVKSCggI1NTX1GT4ikYgikUj0eTgcliQ5jiPHca6kvKhz+3EcR74hJin7vJb05zxc2NcLX3P+OYB99N9d9N9d9N+OePrrMcYk9K9xT0+Pvva1r6mzs1M7d+6UJNXV1WnBggUxYUKSpk6dqrvuukvPPPNMr/1UV1drxYoVvcbr6uqUnZ2dSGkAAMCy7u5uzZ07V11dXfL7/Zecm/CVj4qKCh04cCAaPBJVVVWlysrK6PNwOKz8/HyVlpZetvj+chxH9fX1Kikp0aRVO5Kyz2vJgeqyy86ZWL39ktt9aUbfn9Kj5fvSFOnx9Hu/SI7z/wx4vV63y7nm0H930X87zn1y0R8JhY/HHntMr776qt5++22NHTs2Oh4IBHTmzBl1dnYqNzc3Oh4KhRQIBPrcl8/nk8/n6zXu9XqT/kPi9XoVOetJ6j6vBf05D/3ta6THE53LXwL2peLPFfqP/ruL/qdWPL2N69suxhg99thjeuWVV7Rjxw4VFhbGbJ88ebK8Xq8aGhqiY62trWpra1MwGIznUAAAYJCK68pHRUWF6urq9Itf/ELDhg1TR0eHJCknJ0dZWVnKycnRwoULVVlZqeHDh8vv92vRokUKBoN80wUAAEiKM3ysX79ekvTlL385Zry2tlYPP/ywJGnt2rVKS0tTeXm5IpGIysrKtG7duqQUi6vD+GWvuV0CAGAAiyt89OeLMZmZmaqpqVFNTU3CRQEAgMGL3+0CAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwKp0twsALmX8std6jX20ZrYLlQAAkoUrHwAAwCrCBwAAsIrwAQAArCJ8AAAAq1hwisvqa9FnqvbLYlIAGPy48gEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACs4g6nGHAuvDMqd0UFgIGFKx8AAMAqwgcAALCK8AEAAKwifAAAAKtYcIoB78IFqBKLUAHgahb3lY+3335b99xzj8aMGSOPx6MtW7bEbDfG6Mknn9To0aOVlZWl4uJiHTx4MFn1AgCAAS7u8HHq1Cndeuutqqmp6XP7s88+qxdeeEEbNmzQ7t27dd1116msrEynT5++4mIBAMDAF/fHLrNmzdKsWbP63GaM0fPPP6/vfe97uvfeeyVJP/nJTzRq1Cht2bJFDz744JVVCwAABrykrvk4dOiQOjo6VFxcHB3LycnRtGnT1NTU1Gf4iEQiikQi0efhcFiS5DiOHMdJSl3n9uM4jnxDTFL2ifj40kzM/17Mhec80fOVrJ+dweL8PwOwj/67i/7bEU9/PcaYhP819ng8euWVV3TfffdJknbt2qUZM2aovb1do0ePjs574IEH5PF49PLLL/faR3V1tVasWNFrvK6uTtnZ2YmWBgAALOru7tbcuXPV1dUlv99/ybmuf9ulqqpKlZWV0efhcFj5+fkqLS29bPH95TiO6uvrVVJSokmrdiRln4iPL83o+1N6tHxfmiI9novOO1BdFvN8YvX2hI534X6udef/GfB6vW6Xc82h/+6i/3ac++SiP5IaPgKBgCQpFArFXPkIhUK67bbb+nyNz+eTz+frNe71epP+Q+L1ehU5e/F/+JB6kR7PJc/Bhec80fPFXzB9S8WfK/Qf/XcX/U+teHqb1JuMFRYWKhAIqKGhIToWDoe1e/duBYPBZB4KAAAMUHFf+Th58qQ+/PDD6PNDhw5p//79Gj58uAoKCrRkyRI9/fTTuvHGG1VYWKjly5drzJgx0XUhAADg2hZ3+Ni3b5/uuuuu6PNz6zXmz5+vl156SU888YROnTqlRx99VJ2dnbrzzju1bds2ZWZmJq9qDFp93a0UADC4xB0+vvzlL+tSX5DxeDxauXKlVq5ceUWFAQCAwYlfLAcAAKwifAAAAKsIHwAAwCrXbzIGXC36Wuz60ZrZLlQCAIMbVz4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFV82wW4Slz4bRu+aQNgsOLKBwAAsIrwAQAArCJ8AAAAqwgfAADAKhacYlDqz+LNvm6nnsicC/XnWCwmBXAt48oHAACwivABAACsInwAAACrCB8AAMAqFpzimpDIwtFUSlY9fe0nkcWsydoPAPQHVz4AAIBVhA8AAGAV4QMAAFhF+AAAAFax4BRIslQubk1k3+OXvSbfEKNnp0oTq7crctaTgsriq+dCLG4Fri1c+QAAAFYRPgAAgFWEDwAAYBXhAwAAWMWCU2CQudru5tofF9bMAlRgcOPKBwAAsIrwAQAArCJ8AAAAqwgfAADAKhacAlepgbhwtC/Jeh/92Q8LVe3gLrW4Ulz5AAAAVhE+AACAVYQPAABgFeEDAABYxYJTAP3Sn0WGV9si2UQXRtpc3Jpoz5LV+1S9j8GyAHUgvq+BsDg7ZVc+ampqNH78eGVmZmratGnas2dPqg4FAAAGkJSEj5dfflmVlZV66qmn9M477+jWW29VWVmZjh07lorDAQCAASQl4eO5557TI488ogULFuimm27Shg0blJ2drR//+MepOBwAABhAkr7m48yZM2ppaVFVVVV0LC0tTcXFxWpqauo1PxKJKBKJRJ93dXVJko4fPy7HcZJSk+M46u7u1ieffKL0T08lZZ+IT3qPUXd3j9KdNJ3t8bhdzjUnkf5/8sknsfvo489Of+Yk4sL99nffidTcl0SOdSnn/x3k9XrjPlZ/jp+s/fRHsvuTapfq/+Vc+F6vpvd1MW6dnxMnTkiSjDGXn2yS7MiRI0aS2bVrV8z4448/bqZOndpr/lNPPWUk8eDBgwcPHjwGwePw4cOXzQquf9ulqqpKlZWV0ec9PT06fvy48vLy5PEk5/8hh8Nh5efn6/Dhw/L7/UnZJ+LDOXAX/XcX/XcX/bfDGKMTJ05ozJgxl52b9PAxYsQIDRkyRKFQKGY8FAopEAj0mu/z+eTz+WLGcnNzk12WJMnv9/OD5zLOgbvov7vov7vof+rl5OT0a17SF5xmZGRo8uTJamhoiI719PSooaFBwWAw2YcDAAADTEo+dqmsrNT8+fM1ZcoUTZ06Vc8//7xOnTqlBQsWpOJwAABgAElJ+Pj617+u//mf/9GTTz6pjo4O3Xbbbdq2bZtGjRqVisNdls/n01NPPdXr4x3YwzlwF/13F/13F/2/+niM6c93YgAAAJKDXywHAACsInwAAACrCB8AAMAqwgcAALDqmggfNTU1Gj9+vDIzMzVt2jTt2bPH7ZIGhdWrV+v222/XsGHDNHLkSN13331qbW2NmXP69GlVVFQoLy9PQ4cOVXl5ea8b0LW1tWn27NnKzs7WyJEj9fjjj+vTTz+1+VYGhTVr1sjj8WjJkiXRMfqfWkeOHNE3vvEN5eXlKSsrSzfffLP27dsX3W6M0ZNPPqnRo0crKytLxcXFOnjwYMw+jh8/rnnz5snv9ys3N1cLFy7UyZMnbb+VAefs2bNavny5CgsLlZWVpc9+9rP6/ve/H/N7Rej/VSwJv87lqrZp0yaTkZFhfvzjH5v33nvPPPLIIyY3N9eEQiG3SxvwysrKTG1trTlw4IDZv3+/+cpXvmIKCgrMyZMno3O+9a1vmfz8fNPQ0GD27dtnpk+fbu64447o9k8//dRMnDjRFBcXm3/91381r7/+uhkxYoSpqqpy4y0NWHv27DHjx483t9xyi1m8eHF0nP6nzvHjx824cePMww8/bHbv3m1+85vfmO3bt5sPP/wwOmfNmjUmJyfHbNmyxfz61782X/va10xhYaH57W9/G53zh3/4h+bWW281zc3N5l/+5V/M5z73OfPQQw+58ZYGlFWrVpm8vDzz6quvmkOHDpnNmzeboUOHmh/+8IfROfT/6jXow8fUqVNNRUVF9PnZs2fNmDFjzOrVq12sanA6duyYkWQaGxuNMcZ0dnYar9drNm/eHJ3z7//+70aSaWpqMsYY8/rrr5u0tDTT0dERnbN+/Xrj9/tNJBKx+wYGqBMnTpgbb7zR1NfXmy996UvR8EH/U+u73/2uufPOOy+6vaenxwQCAfNXf/VX0bHOzk7j8/nM3//93xtjjHn//feNJLN3797onDfeeMN4PB5z5MiR1BU/CMyePdt885vfjBmbM2eOmTdvnjGG/l/tBvXHLmfOnFFLS4uKi4ujY2lpaSouLlZTU5OLlQ1OXV1dkqThw4dLklpaWuQ4Tkz/i4qKVFBQEO1/U1OTbr755pgb0JWVlSkcDuu9996zWP3AVVFRodmzZ8f0WaL/qfbLX/5SU6ZM0f3336+RI0dq0qRJ+tGPfhTdfujQIXV0dMT0PycnR9OmTYvpf25urqZMmRKdU1xcrLS0NO3evdvemxmA7rjjDjU0NOiDDz6QJP3617/Wzp07NWvWLEn0/2rn+m+1TaWPP/5YZ8+e7XVn1VGjRuk//uM/XKpqcOrp6dGSJUs0Y8YMTZw4UZLU0dGhjIyMXr8ocNSoUero6IjO6ev8nNuGS9u0aZPeeecd7d27t9c2+p9av/nNb7R+/XpVVlbqL/7iL7R371595zvfUUZGhubPnx/tX1/9Pb//I0eOjNmenp6u4cOH0//LWLZsmcLhsIqKijRkyBCdPXtWq1at0rx58ySJ/l/lBnX4gD0VFRU6cOCAdu7c6XYp14zDhw9r8eLFqq+vV2ZmptvlXHN6eno0ZcoU/eAHP5AkTZo0SQcOHNCGDRs0f/58l6sb/P7hH/5BP/vZz1RXV6cvfOEL2r9/v5YsWaIxY8bQ/wFgUH/sMmLECA0ZMqTX6v5QKKRAIOBSVYPPY489pldffVX//M//rLFjx0bHA4GAzpw5o87Ozpj55/c/EAj0eX7ObcPFtbS06NixY/riF7+o9PR0paenq7GxUS+88ILS09M1atQo+p9Co0eP1k033RQzNmHCBLW1tUn6//5d6u+fQCCgY8eOxWz/9NNPdfz4cfp/GY8//riWLVumBx98UDfffLP++I//WEuXLtXq1asl0f+r3aAOHxkZGZo8ebIaGhqiYz09PWpoaFAwGHSxssHBGKPHHntMr7zyinbs2KHCwsKY7ZMnT5bX643pf2trq9ra2qL9DwaDevfdd2P+Aqivr5ff7+/1Fzti3X333Xr33Xe1f//+6GPKlCmaN29e9L/pf+rMmDGj11fLP/jgA40bN06SVFhYqEAgENP/cDis3bt3x/S/s7NTLS0t0Tk7duxQT0+Ppk2bZuFdDFzd3d1KS4v9J2zIkCHq6emRRP+vem6veE21TZs2GZ/PZ1566SXz/vvvm0cffdTk5ubGrO5HYv70T//U5OTkmLfeesscPXo0+uju7o7O+da3vmUKCgrMjh07zL59+0wwGDTBYDC6/dxXPUtLS83+/fvNtm3bzA033MBXPRN0/rddjKH/qbRnzx6Tnp5uVq1aZQ4ePGh+9rOfmezsbPPTn/40OmfNmjUmNzfX/OIXvzD/9m//Zu69994+v+o5adIks3v3brNz505z44038lXPfpg/f775zGc+E/2q7c9//nMzYsQI88QTT0Tn0P+r16APH8YY8zd/8zemoKDAZGRkmKlTp5rm5ma3SxoUJPX5qK2tjc757W9/a7797W+b66+/3mRnZ5s/+qM/MkePHo3Zz0cffWRmzZplsrKyzIgRI8yf/dmfGcdxLL+bweHC8EH/U2vr1q1m4sSJxufzmaKiIvPiiy/GbO/p6THLly83o0aNMj6fz9x9992mtbU1Zs4nn3xiHnroITN06FDj9/vNggULzIkTJ2y+jQEpHA6bxYsXm4KCApOZmWl+7/d+z/zlX/5lzFfE6f/Vy2PMebeDAwAASLFBveYDAABcfQgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArPo/vIUUQyDa0g0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "wic_addresses_per_zip.hist(bins=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "af278e41",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    857.000000\n",
+       "mean     144.444574\n",
+       "std      131.022121\n",
+       "min        3.000000\n",
+       "25%       50.000000\n",
+       "50%      116.000000\n",
+       "75%      195.000000\n",
+       "max      940.000000\n",
+       "Name: address_id, dtype: float64"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wic_addresses_per_zip.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "648b3030",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6.053547850750648"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_wic.address_id.nunique() / len(address_to_zip)"
    ]
   },
   {
@@ -3221,7 +3848,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 64,
    "id": "4a4f34c8",
    "metadata": {},
    "outputs": [
@@ -3239,7 +3866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 65,
    "id": "ac497f02",
    "metadata": {},
    "outputs": [
@@ -3247,25 +3874,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "total 16580\n",
-      "-rw-rw-r-- 1 ndbs Domain Users 16972022 Feb  8 15:36 census_index_to_zipcode_2023_02_02_10_16_21.csv.bz2\n",
-      "CPU times: user 10.4 s, sys: 16.4 ms, total: 10.4 s\n",
-      "Wall time: 10.9 s\n"
+      "total 700\n",
+      "-rw-rw-r-- 1 ndbs Domain Users 710226 Feb  9 22:50 address_id_to_zipcode_2023_02_02_10_16_21.csv.bz2\n",
+      "CPU times: user 366 ms, sys: 40.2 ms, total: 406 ms\n",
+      "Wall time: 604 ms\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "save_dir = '/share/scratch/users/ndbs/prl'\n",
-    "save_filename = 'census_index_to_zipcode_2023_02_02_10_16_21.csv.bz2'\n",
+    "save_filename = 'address_id_to_zipcode_2023_02_02_10_16_21.csv.bz2'\n",
     "save_filepath = f'{save_dir}/{save_filename}'\n",
-    "census_zips['zipcode'].to_csv(save_filepath)\n",
+    "address_id_to_zip['zipcode'].to_csv(save_filepath)\n",
     "!ls -l $save_dir"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 66,
    "id": "f52b6e39",
    "metadata": {},
    "outputs": [
@@ -3273,8 +3900,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5.76 s, sys: 283 ms, total: 6.04 s\n",
-      "Wall time: 6.04 s\n"
+      "CPU times: user 203 ms, sys: 11.9 ms, total: 214 ms\n",
+      "Wall time: 214 ms\n"
      ]
     },
     {
@@ -3300,75 +3927,80 @@
        "      <th></th>\n",
        "      <th>zipcode</th>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>address_id</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>33462</td>\n",
+       "      <td>34266</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>33462</td>\n",
+       "      <td>33434</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>33462</td>\n",
+       "      <td>32807</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>33811</td>\n",
+       "      <td>33993</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>32730</td>\n",
+       "      <td>32174</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4943280</th>\n",
-       "      <td>34741</td>\n",
+       "      <th>189908</th>\n",
+       "      <td>33908</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4943281</th>\n",
-       "      <td>33993</td>\n",
+       "      <th>189909</th>\n",
+       "      <td>32217</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4943282</th>\n",
-       "      <td>32792</td>\n",
+       "      <th>189910</th>\n",
+       "      <td>32433</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4943283</th>\n",
-       "      <td>34224</td>\n",
+       "      <th>189911</th>\n",
+       "      <td>33033</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4943284</th>\n",
-       "      <td>33914</td>\n",
+       "      <th>189912</th>\n",
+       "      <td>33981</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>4943285 rows × 1 columns</p>\n",
+       "<p>189913 rows × 1 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "        zipcode\n",
-       "0         33462\n",
-       "1         33462\n",
-       "2         33462\n",
-       "3         33811\n",
-       "4         32730\n",
-       "...         ...\n",
-       "4943280   34741\n",
-       "4943281   33993\n",
-       "4943282   32792\n",
-       "4943283   34224\n",
-       "4943284   33914\n",
+       "           zipcode\n",
+       "address_id        \n",
+       "0            34266\n",
+       "1            33434\n",
+       "2            32807\n",
+       "3            33993\n",
+       "4            32174\n",
+       "...            ...\n",
+       "189908       33908\n",
+       "189909       32217\n",
+       "189910       32433\n",
+       "189911       33033\n",
+       "189912       33981\n",
        "\n",
-       "[4943285 rows x 1 columns]"
+       "[189913 rows x 1 columns]"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3381,7 +4013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 67,
    "id": "d5a92c59",
    "metadata": {},
    "outputs": [
@@ -3392,7 +4024,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 137,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3403,22 +4035,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 68,
    "id": "4ca89d02",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Int64Index([      0,       1,       2,       3,       4,       5,       6,\n",
-       "                  7,       8,       9,\n",
+       "Int64Index([     0,      1,      2,      3,      4,      5,      6,      7,\n",
+       "                 8,      9,\n",
        "            ...\n",
-       "            4943275, 4943276, 4943277, 4943278, 4943279, 4943280, 4943281,\n",
-       "            4943282, 4943283, 4943284],\n",
-       "           dtype='int64', length=4943285)"
+       "            189903, 189904, 189905, 189906, 189907, 189908, 189909, 189910,\n",
+       "            189911, 189912],\n",
+       "           dtype='int64', name='address_id', length=189913)"
       ]
      },
-     "execution_count": 138,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/linkage/wic_case_study/2023_02_07a_assign_zipcodes.ipynb
+++ b/linkage/wic_case_study/2023_02_07a_assign_zipcodes.ipynb
@@ -1,0 +1,3460 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "50cb86d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tue 07 Feb 2023 12:19:16 PM PST\n",
+      "ndbs\n",
+      "Linux int-slurm-sarchive-p0004 5.4.0-89-generic #100-Ubuntu SMP Fri Sep 24 14:50:10 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux\n",
+      "/mnt/share/code/ndbs/vivarium_research_prl/linkage/wic_case_study\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np, matplotlib.pyplot as plt, pandas as pd\n",
+    "pd.set_option('display.max_rows', 40)\n",
+    "\n",
+    "from vivarium_research_prl.noise import corruption, fake_names, noisify\n",
+    "\n",
+    "!date\n",
+    "!whoami\n",
+    "!uname -a\n",
+    "!pwd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d92cd2a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8773162",
+   "metadata": {},
+   "source": [
+    "# Goal: Assign zipcodes to new census data that only has address IDs\n",
+    "\n",
+    "We can use use the zipcodes from the `2022_10_14_10_49_32` data that has both address and zipcode columns. The idea is to map each unique address ID in the new `2023_02_02_10_16_21` data to an address in the old data, then use the zipcode for that address. The goal is to have the relative number of addreses per zipcode be about the same as in the old data. I'm not concerned with getting address strings for the address IDs, because I can just convert each ID to a string and use that as the address for linking."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86f448d8",
+   "metadata": {},
+   "source": [
+    "# Define directories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "550591be",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 32224\r\n",
+      "-rw-rw-r-- 1 albrja   IHME-Simulationscience 12622072 Oct 20 23:08 decennial_census.hdf\r\n",
+      "-rwxrwxrwx 1 beatrixh IHME-Simulationscience 20364830 Nov 14 16:42 state_table.hdf\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "project_output_dir = '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop'\n",
+    "orig_data_subdir = 'results/special_last_names/florida/2022_10_14_10_49_32/population_table/'\n",
+    "orig_data_dir = f'{project_output_dir}/{orig_data_subdir}'\n",
+    "\n",
+    "new_data_subdir = 'results/vv_post_processing_first_middle_names/united_states_of_america/2023_02_02_10_16_21/'\n",
+    "new_data_subsubdir = 'final_results/2023_02_02_11_10_52'\n",
+    "new_data_dir = f'{project_output_dir}/{new_data_subdir}/{new_data_subsubdir}'\n",
+    "\n",
+    "!ls -l $orig_data_dir\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "054670c9",
+   "metadata": {},
+   "source": [
+    "# Load state table from original data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c22950b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tracked</th>\n",
+       "      <th>middle_name</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>relation_to_household_head</th>\n",
+       "      <th>race_ethnicity</th>\n",
+       "      <th>housing_type</th>\n",
+       "      <th>exit_time</th>\n",
+       "      <th>last_name</th>\n",
+       "      <th>state</th>\n",
+       "      <th>ssn</th>\n",
+       "      <th>...</th>\n",
+       "      <th>years_of_life_lost</th>\n",
+       "      <th>cause_of_death</th>\n",
+       "      <th>zipcode</th>\n",
+       "      <th>address</th>\n",
+       "      <th>parent_id</th>\n",
+       "      <th>last_birth_time</th>\n",
+       "      <th>employer_id</th>\n",
+       "      <th>employer_name</th>\n",
+       "      <th>employer_zipcode</th>\n",
+       "      <th>employer_address</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Jenny</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Clark</td>\n",
+       "      <td>12</td>\n",
+       "      <td>486-24-8278</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>34601</td>\n",
+       "      <td>1344 winoka rd  brooksville, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>2019-03-04 18:00:00</td>\n",
+       "      <td>46</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>33187</td>\n",
+       "      <td>2408 brookshire dr  sunset corners, fl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Virgil</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Littlejohn</td>\n",
+       "      <td>12</td>\n",
+       "      <td>108-89-8623</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>34698</td>\n",
+       "      <td>927 23rd st  clearwater, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>193</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>33948</td>\n",
+       "      <td>144 tulip ln  prt charlotte, fl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Annaliese</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Biological child</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Jackson</td>\n",
+       "      <td>12</td>\n",
+       "      <td>788-05-3097</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>34698</td>\n",
+       "      <td>927 23rd st  clearwater, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>2019-03-04 18:00:00</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>unemployed</td>\n",
+       "      <td>NA</td>\n",
+       "      <td>NA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Devyn</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Stepchild</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Cox</td>\n",
+       "      <td>12</td>\n",
+       "      <td></td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>34698</td>\n",
+       "      <td>927 23rd st  clearwater, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>204</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>33169</td>\n",
+       "      <td>1835 harvard dr  hialeah, fl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Jonathan</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Tucker</td>\n",
+       "      <td>12</td>\n",
+       "      <td>009-31-4192</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>32003</td>\n",
+       "      <td>8904 167th place  fleming island, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>176</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>34293</td>\n",
+       "      <td>2607 e bluefield ave  venice, fl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49995</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Nicholas</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Institutionalized GQ pop</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Other institutional</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Roberts</td>\n",
+       "      <td>12</td>\n",
+       "      <td>625-97-5353</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>33919</td>\n",
+       "      <td>114 s frnt st  fort myers, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>unemployed</td>\n",
+       "      <td>NA</td>\n",
+       "      <td>NA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49996</th>\n",
+       "      <td>True</td>\n",
+       "      <td>John</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Institutionalized GQ pop</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Carceral</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Campbell</td>\n",
+       "      <td>12</td>\n",
+       "      <td>238-09-2208</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>33021</td>\n",
+       "      <td>2210 henn hyde rd ne  hollywood, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>unemployed</td>\n",
+       "      <td>NA</td>\n",
+       "      <td>NA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49997</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Charles</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Institutionalized GQ pop</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>Nursing home</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Rosales</td>\n",
+       "      <td>12</td>\n",
+       "      <td>650-80-3526</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>32968</td>\n",
+       "      <td>701 haber rd  vero beach, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>unemployed</td>\n",
+       "      <td>NA</td>\n",
+       "      <td>NA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49998</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Jermaine</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Institutionalized GQ pop</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Other institutional</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Morton</td>\n",
+       "      <td>12</td>\n",
+       "      <td>784-92-1608</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>33919</td>\n",
+       "      <td>114 s frnt st  fort myers, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>19</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>33444</td>\n",
+       "      <td>92 address unassigned  delray beach, fl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49999</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Helen</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Institutionalized GQ pop</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>Nursing home</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Talley</td>\n",
+       "      <td>12</td>\n",
+       "      <td>839-05-1155</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>32968</td>\n",
+       "      <td>701 haber rd  vero beach, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>2019-03-04 18:00:00</td>\n",
+       "      <td>204</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>33169</td>\n",
+       "      <td>1835 harvard dr  hialeah, fl</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>50000 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       tracked middle_name     sex relation_to_household_head race_ethnicity  \\\n",
+       "0         True       Jenny  Female           Reference person          Black   \n",
+       "1         True      Virgil    Male           Reference person          Black   \n",
+       "2         True   Annaliese  Female           Biological child          Black   \n",
+       "3         True       Devyn    Male                  Stepchild          Black   \n",
+       "4         True    Jonathan    Male           Reference person          White   \n",
+       "...        ...         ...     ...                        ...            ...   \n",
+       "49995     True    Nicholas    Male   Institutionalized GQ pop          White   \n",
+       "49996     True        John    Male   Institutionalized GQ pop          White   \n",
+       "49997     True     Charles    Male   Institutionalized GQ pop         Latino   \n",
+       "49998     True    Jermaine    Male   Institutionalized GQ pop          White   \n",
+       "49999     True       Helen  Female   Institutionalized GQ pop          Black   \n",
+       "\n",
+       "              housing_type exit_time   last_name  state          ssn  ...  \\\n",
+       "0                 Standard       NaT       Clark     12  486-24-8278  ...   \n",
+       "1                 Standard       NaT  Littlejohn     12  108-89-8623  ...   \n",
+       "2                 Standard       NaT     Jackson     12  788-05-3097  ...   \n",
+       "3                 Standard       NaT         Cox     12               ...   \n",
+       "4                 Standard       NaT      Tucker     12  009-31-4192  ...   \n",
+       "...                    ...       ...         ...    ...          ...  ...   \n",
+       "49995  Other institutional       NaT     Roberts     12  625-97-5353  ...   \n",
+       "49996             Carceral       NaT    Campbell     12  238-09-2208  ...   \n",
+       "49997         Nursing home       NaT     Rosales     12  650-80-3526  ...   \n",
+       "49998  Other institutional       NaT      Morton     12  784-92-1608  ...   \n",
+       "49999         Nursing home       NaT      Talley     12  839-05-1155  ...   \n",
+       "\n",
+       "      years_of_life_lost cause_of_death zipcode  \\\n",
+       "0                    0.0       not_dead   34601   \n",
+       "1                    0.0       not_dead   34698   \n",
+       "2                    0.0       not_dead   34698   \n",
+       "3                    0.0       not_dead   34698   \n",
+       "4                    0.0       not_dead   32003   \n",
+       "...                  ...            ...     ...   \n",
+       "49995                0.0       not_dead   33919   \n",
+       "49996                0.0       not_dead   33021   \n",
+       "49997                0.0       not_dead   32968   \n",
+       "49998                0.0       not_dead   33919   \n",
+       "49999                0.0       not_dead   32968   \n",
+       "\n",
+       "                                    address  parent_id     last_birth_time  \\\n",
+       "0           1344 winoka rd  brooksville, fl         -1 2019-03-04 18:00:00   \n",
+       "1               927 23rd st  clearwater, fl         -1                 NaT   \n",
+       "2               927 23rd st  clearwater, fl         -1 2019-03-04 18:00:00   \n",
+       "3               927 23rd st  clearwater, fl         -1                 NaT   \n",
+       "4      8904 167th place  fleming island, fl         -1                 NaT   \n",
+       "...                                     ...        ...                 ...   \n",
+       "49995         114 s frnt st  fort myers, fl         -1                 NaT   \n",
+       "49996   2210 henn hyde rd ne  hollywood, fl         -1                 NaT   \n",
+       "49997          701 haber rd  vero beach, fl         -1                 NaT   \n",
+       "49998         114 s frnt st  fort myers, fl         -1                 NaT   \n",
+       "49999          701 haber rd  vero beach, fl         -1 2019-03-04 18:00:00   \n",
+       "\n",
+       "       employer_id    employer_name employer_zipcode  \\\n",
+       "0               46  not implemented            33187   \n",
+       "1              193  not implemented            33948   \n",
+       "2               -1       unemployed               NA   \n",
+       "3              204  not implemented            33169   \n",
+       "4              176  not implemented            34293   \n",
+       "...            ...              ...              ...   \n",
+       "49995           -1       unemployed               NA   \n",
+       "49996           -1       unemployed               NA   \n",
+       "49997           -1       unemployed               NA   \n",
+       "49998           19  not implemented            33444   \n",
+       "49999          204  not implemented            33169   \n",
+       "\n",
+       "                              employer_address  \n",
+       "0       2408 brookshire dr  sunset corners, fl  \n",
+       "1              144 tulip ln  prt charlotte, fl  \n",
+       "2                                           NA  \n",
+       "3                 1835 harvard dr  hialeah, fl  \n",
+       "4             2607 e bluefield ave  venice, fl  \n",
+       "...                                        ...  \n",
+       "49995                                       NA  \n",
+       "49996                                       NA  \n",
+       "49997                                       NA  \n",
+       "49998  92 address unassigned  delray beach, fl  \n",
+       "49999             1835 harvard dr  hialeah, fl  \n",
+       "\n",
+       "[50000 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "state_table_path = f'{orig_data_dir}/state_table.hdf'\n",
+    "df_state_table = pd.read_hdf(state_table_path, 'ymd_2020_4_1')\n",
+    "df_state_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fc937fb",
+   "metadata": {},
+   "source": [
+    "# Look at how addresses are distributed among zipcodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "41321ab2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "zipcode\n",
+       "cp34714      1\n",
+       "32420        1\n",
+       "32357        1\n",
+       "cp34110      1\n",
+       "32312        1\n",
+       "          ... \n",
+       "33908      114\n",
+       "32218      120\n",
+       "33974      138\n",
+       "33993      154\n",
+       "34953      155\n",
+       "Name: address, Length: 864, dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "address_counts = df_state_table.groupby('zipcode')['address'].nunique().sort_values()\n",
+    "address_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0b61583b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "33919      460\n",
+       "33993      406\n",
+       "34953      403\n",
+       "32968      358\n",
+       "33021      351\n",
+       "          ... \n",
+       "cp34110      1\n",
+       "32445        1\n",
+       "33827        1\n",
+       "32024        1\n",
+       "33132        1\n",
+       "Name: zipcode, Length: 864, dtype: int64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_state_table.zipcode.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "df189273",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot: >"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiQAAAGdCAYAAAAi3mhQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAjMUlEQVR4nO3dfXBU1eH/8c8mWZbwkABhIEQCpBYHBQTKkxGmPgViBwWEERW0FB2pGpSQDgKtgYAPEBwxBRHEsVinRpGpoOAIpkGjDOHBACqFAaZFoGBCFUmQyLLNnt8fftmfm0STTRZOsvf9msnEPffu2fPJhs3Hu3d3XcYYIwAAAIuibC8AAACAQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAuhjbC6jO7/fr5MmTatu2rVwul+3lAACAejDG6OzZs0pKSlJUVOjHO5pcITl58qSSk5NtLwMAADTA8ePH1bVr15Cv1+QKSdu2bSX9ECguLq7R8/l8Pn3wwQcaOXKk3G53o+drypyS1Sk5JedkdUpOyTlZnZJTck7WunJWVFQoOTk58Hc8VE2ukFx8miYuLi5shaRVq1aKi4uL6F8UyTlZnZJTck5Wp+SUnJPVKTkl52Stb86Gnm7BSa0AAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALAuxvYCLrces98LuvzlolGWVgIAAC7iCAkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKwLqZBUVVUpOztbKSkpio2N1ZVXXqknn3xSxpjAPsYYzZ07V126dFFsbKzS0tJ0+PDhsC8cAABEjpAKSW5urlasWKEXXnhBBw4cUG5urhYvXqxly5YF9lm8eLGWLl2qlStXaseOHWrdurXS09N1/vz5sC8eAABEhphQdt62bZvGjBmjUaNGSZJ69OihN954Qzt37pT0w9GRvLw8PfHEExozZowk6bXXXlPnzp21fv163X333WFePgAAiAQhFZLrr79eq1at0qFDh3TVVVfps88+09atW7VkyRJJ0pEjR1RaWqq0tLTAdeLj4zV06FAVFxfXWki8Xq+8Xm/gckVFhSTJ5/PJ5/M1KNSPXZzj4ndPtKl1eySonjVSOSWn5JysTskpOSerU3JKzslaV87G5neZH58AUge/368//vGPWrx4saKjo1VVVaWnn35ac+bMkfTDEZRhw4bp5MmT6tKlS+B6EyZMkMvl0po1a2rMmZOTo/nz59cYz8/PV6tWrRqSCQAAXGaVlZWaOHGiysvLFRcXF/L1QzpC8tZbb+n1119Xfn6+evfurb179yozM1NJSUmaPHlyyDcuSXPmzFFWVlbgckVFhZKTkzVy5MgGBarO5/OpoKBAI0aMkNvtVp+czUHb9+WkN/o2morqWSOVU3JKzsnqlJySc7I6JafknKx15bz4DEdDhVRIZs6cqdmzZweeeunbt6+OHj2qhQsXavLkyUpMTJQklZWVBR0hKSsrU//+/Wud0+PxyOPx1Bh3u91hvWMvzuetctUYjzTh/tk1VU7JKTknq1NySs7J6pScknOy/lTOxmYP6VU2lZWViooKvkp0dLT8fr8kKSUlRYmJiSosLAxsr6io0I4dO5SamtqohQIAgMgV0hGS22+/XU8//bS6deum3r17a8+ePVqyZInuv/9+SZLL5VJmZqaeeuop9ezZUykpKcrOzlZSUpLGjh17KdYPAAAiQEiFZNmyZcrOztYjjzyiU6dOKSkpSb///e81d+7cwD6PP/64zp07p6lTp+rMmTMaPny4Nm3apJYtW4Z98QAAIDKEVEjatm2rvLw85eXl/eQ+LpdLCxYs0IIFCxq7NgAA4BB8lg0AALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArAu5kJw4cUL33nuvEhISFBsbq759++rTTz8NbDfGaO7cuerSpYtiY2OVlpamw4cPh3XRAAAgsoRUSL799lsNGzZMbrdb77//vvbv36/nnntO7du3D+yzePFiLV26VCtXrtSOHTvUunVrpaen6/z582FfPAAAiAwxoeycm5ur5ORkrV69OjCWkpIS+G9jjPLy8vTEE09ozJgxkqTXXntNnTt31vr163X33XeHadkAACCShFRI3n33XaWnp+vOO+9UUVGRrrjiCj3yyCN68MEHJUlHjhxRaWmp0tLSAteJj4/X0KFDVVxcXGsh8Xq98nq9gcsVFRWSJJ/PJ5/P16BQP3ZxjovfPdGm1u2RoHrWSOWUnJJzsjolp+ScrE7JKTkna105G5vfZYwxde/2g5YtW0qSsrKydOedd2rXrl2aPn26Vq5cqcmTJ2vbtm0aNmyYTp48qS5dugSuN2HCBLlcLq1Zs6bGnDk5OZo/f36N8fz8fLVq1aohmQAAwGVWWVmpiRMnqry8XHFxcSFfP6RC0qJFCw0aNEjbtm0LjD322GPatWuXiouLG1RIajtCkpycrK+//rpBgarz+XwqKCjQiBEj5Ha71Sdnc9D2fTnpjb6NpqJ61kjllJySc7I6JafknKxOySk5J2tdOSsqKtSxY8cGF5KQnrLp0qWLrrnmmqCxq6++Wn//+98lSYmJiZKksrKyoEJSVlam/v371zqnx+ORx+OpMe52u8N6x16cz1vlqjEeacL9s2uqnJJTck5Wp+SUnJPVKTkl52T9qZyNzR7Sq2yGDRumgwcPBo0dOnRI3bt3l/TDCa6JiYkqLCwMbK+oqNCOHTuUmpraqIUCAIDIFdIRkhkzZuj666/XM888owkTJmjnzp1atWqVVq1aJUlyuVzKzMzUU089pZ49eyolJUXZ2dlKSkrS2LFjL8X6AQBABAipkAwePFjr1q3TnDlztGDBAqWkpCgvL0+TJk0K7PP444/r3Llzmjp1qs6cOaPhw4dr06ZNgRNiAQAAqgupkEjSbbfdpttuu+0nt7tcLi1YsEALFixo1MIAAIBz8Fk2AADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOtibC/Ath6z36sx9uWiURZWAgCAc3GEBAAAWEchAQAA1lFIAACAdRQSAABgHYUEAABYRyEBAADWUUgAAIB1FBIAAGAdhQQAAFhHIQEAANZRSAAAgHUUEgAAYB2FBAAAWEchAQAA1lFIAACAdRQSAABgHYUEAABYRyEBAADWUUgAAIB1FBIAAGAdhQQAAFhHIQEAANbF2F4AgvWY/V6NsS8XjarX9TzRRouHSH1yNstb5arX9QAAaAo4QgIAAKyjkAAAAOsoJAAAwDrOIQmThp77AQAAOEICAACaAAoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCuUYVk0aJFcrlcyszMDIydP39eGRkZSkhIUJs2bTR+/HiVlZU1dp0AACCCNbiQ7Nq1Sy+99JKuvfbaoPEZM2Zow4YNWrt2rYqKinTy5EmNGzeu0QsFAACRq0GF5LvvvtOkSZP08ssvq3379oHx8vJyvfLKK1qyZIluvvlmDRw4UKtXr9a2bdu0ffv2sC0aAABElgYVkoyMDI0aNUppaWlB4yUlJfL5fEHjvXr1Urdu3VRcXNy4lQIAgIgV8lvHv/nmm9q9e7d27dpVY1tpaalatGihdu3aBY137txZpaWltc7n9Xrl9XoDlysqKiRJPp9PPp8v1OXVcHGOi9890abe1wlFbfNeznk80UaeqB+ue/F7OH5+TVH1+zSSOSWrU3JKzsnqlJySc7LWlbOx+V3GmLr/Qv+f48ePa9CgQSooKAicO3LjjTeqf//+ysvLU35+vqZMmRJUMCRpyJAhuummm5Sbm1tjzpycHM2fP7/GeH5+vlq1ahVqHgAAYEFlZaUmTpyo8vJyxcXFhXz9kArJ+vXrdccddyg6OjowVlVVJZfLpaioKG3evFlpaWn69ttvg46SdO/eXZmZmZoxY0aNOWs7QpKcnKyvv/66QYGq8/l8Kigo0IgRI+R2u9UnZ3Od19mXkx7y7dQ27+Wcp0/OZnmijJ4c5Ff2p1Hy+l0Nuv3moPp9GsmcktUpOSXnZHVKTsk5WevKWVFRoY4dOza4kIT0lM0tt9yiL774ImhsypQp6tWrl2bNmqXk5GS53W4VFhZq/PjxkqSDBw/q2LFjSk1NrXVOj8cjj8dTY9ztdof1jr04n7fKVa99Q1XbvJdznh9fz+t3yVvliuh/GFL4f0eaMqdkdUpOyTlZnZJTck7Wn8rZ2OwhFZK2bduqT58+QWOtW7dWQkJCYPyBBx5QVlaWOnTooLi4OD366KNKTU3Vdddd16iFovF6zH6vxtiXi0ZZWAkAAMFCPqm1Ls8//7yioqI0fvx4eb1epaen68UXXwz3zQAAgAjS6ELy0UcfBV1u2bKlli9fruXLlzd2agAA4BB8lg0AALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsC7sL/uNRE3t/TtqWw8AAM0ZR0gAAIB1FBIAAGAdhQQAAFjHOSSXUVM7FwUAgKaCIyQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsC7G9gLQtPSY/V6NsS8XjbKwEgCAk3CEBAAAWEchAQAA1lFIAACAdRQSAABgHYUEAABYRyEBAADWUUgAAIB1vA9JM1Dbe4MAABBJOEICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOt42e8lxMt1AQCoH46QAAAA6ygkAADAOgoJAACwjnNIasG5Hz+vtp/Pl4tGWVgJACBScIQEAABYRyEBAADWUUgAAIB1nEPicJwvAwBoCjhCAgAArKOQAAAA6ygkAADAupAKycKFCzV48GC1bdtWnTp10tixY3Xw4MGgfc6fP6+MjAwlJCSoTZs2Gj9+vMrKysK6aAAAEFlCKiRFRUXKyMjQ9u3bVVBQIJ/Pp5EjR+rcuXOBfWbMmKENGzZo7dq1Kioq0smTJzVu3LiwLxwAAESOkF5ls2nTpqDLr776qjp16qSSkhL9+te/Vnl5uV555RXl5+fr5ptvliStXr1aV199tbZv367rrrsufCsHAAARo1Ev+y0vL5ckdejQQZJUUlIin8+ntLS0wD69evVSt27dVFxcXGsh8Xq98nq9gcsVFRWSJJ/PJ5/P15jlBeb58XdPtGn0nD+e76KGzhuueSTJE2WCvl/ONYbjvqqv6vdpJHNKVqfklJyT1Sk5JedkrStnY/O7jDEN+ivl9/s1evRonTlzRlu3bpUk5efna8qUKUEFQ5KGDBmim266Sbm5uTXmycnJ0fz582uM5+fnq1WrVg1ZGgAAuMwqKys1ceJElZeXKy4uLuTrN/gISUZGhvbt2xcoIw01Z84cZWVlBS5XVFQoOTlZI0eObFCg6nw+nwoKCjRixAi53W71ydnc6DklaV9OetDlhs4brnmkH46MPDnIr+xPo+T1uy7rGi/VPrWpfp9GMqdkdUpOyTlZnZJTck7WunJefIajoRpUSKZNm6aNGzfq448/VteuXQPjiYmJunDhgs6cOaN27doFxsvKypSYmFjrXB6PRx6Pp8a42+0O6x17cT5vlSts8/1YQ+cN1zxBc/hd8la5LusaL9U+da0rkv/x/5hTsjolp+ScrE7JKTkn60/lbGz2kF5lY4zRtGnTtG7dOm3ZskUpKSlB2wcOHCi3263CwsLA2MGDB3Xs2DGlpqY2aqEAACByhXSEJCMjQ/n5+XrnnXfUtm1blZaWSpLi4+MVGxur+Ph4PfDAA8rKylKHDh0UFxenRx99VKmpqRH3Cpvm8BkwzWGNdaktw+EnR1pYCQDgUgqpkKxYsUKSdOONNwaNr169Wr/73e8kSc8//7yioqI0fvx4eb1epaen68UXXwzLYgEAQGQKqZDU5wU5LVu21PLly7V8+fIGLwoAADgLn2UDAACsa9QbowEXRcL5KgAAezhCAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOsoJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACso5AAAADrKCQAAMA6CgkAALCOQgIAAKyjkAAAAOtibC/A6XrMfs/2Ei6bppa1+nq+XDTK0koAABwhAQAA1lFIAACAdRQSAABgHeeQoE5N7dyPPjmbtXjID9+9VS7r535wLgoANB5HSAAAgHUUEgAAYB2FBAAAWEchAQAA1lFIAACAdRQSAABgHYUEAABYRyEBAADWUUgAAIB1FBIAAGAdbx2PiBSut3NvavOE47Yv9+0DQH1whAQAAFhHIQEAANZRSAAAgHWcQ4ImpbbzHQAAkY8jJAAAwDoKCQAAsI5CAgAArKOQAAAA6ygkAADAOgoJAACwjkICAACs431I0OxF6nuX9Jj9njzRRouHSH1yNstb5eIzaABELI6QAAAA6ygkAADAOgoJAACwjnNI4AjhOs+kPvM09LYacr3arsN5JgCaI46QAAAA6ygkAADAOgoJAACwjnNIAAsu53km9ZknXOed1Gd9nOMCoDYcIQEAANZRSAAAgHUUEgAAYB3nkAARpqmfZ1KbPjmbgz6zpz4i9VyUS/neMvWZm/e2iTzN5T7lCAkAALCOQgIAAKy7ZE/ZLF++XM8++6xKS0vVr18/LVu2TEOGDLlUNwegERr6lvgNOexb2zye6JCnuaxPP4Tr5cw9Zr8nT7QJenqqvtdryO3ZVNvTcE19zbW5nE9dOt0lOUKyZs0aZWVlad68edq9e7f69eun9PR0nTp16lLcHAAAaOYuSSFZsmSJHnzwQU2ZMkXXXHONVq5cqVatWukvf/nLpbg5AADQzIX9KZsLFy6opKREc+bMCYxFRUUpLS1NxcXFNfb3er3yer2By+Xl5ZKk06dPy+fzNXo9Pp9PlZWV+uabb+R2uxXzv3ONnrOpivEbVVb6FeOLUpW/fq9UaI4uVc5vvvmm5m1Z/n1p6vdp9Z9ZQ39e4cpZn/XUdj/Xub565KrPvDH/O1cja0N/huHKccl+Zr5zNe7ThsxjW/WfR20Zqv+daWrCdZ/WlfPs2bOSJGNM6Iv8vyuG1YkTJ4wks23btqDxmTNnmiFDhtTYf968eUYSX3zxxRdffPEVAV/Hjx9vUH+w/j4kc+bMUVZWVuCy3+/X6dOnlZCQIJer8f9HWFFRoeTkZB0/flxxcXGNnq8pc0pWp+SUnJPVKTkl52R1Sk7JOVnrymmM0dmzZ5WUlNSg+cNeSDp27Kjo6GiVlZUFjZeVlSkxMbHG/h6PRx6PJ2isXbt24V6W4uLiIvoX5cecktUpOSXnZHVKTsk5WZ2SU3JO1p/LGR8f3+B5w35Sa4sWLTRw4EAVFhYGxvx+vwoLC5WamhrumwMAABHgkjxlk5WVpcmTJ2vQoEEaMmSI8vLydO7cOU2ZMuVS3BwAAGjmLkkhueuuu/Tf//5Xc+fOVWlpqfr3769Nmzapc+fOl+LmfpbH49G8efNqPC0UiZyS1Sk5JedkdUpOyTlZnZJTck7WS53TZUxDX58DAAAQHnyWDQAAsI5CAgAArKOQAAAA6ygkAADAuoguJMuXL1ePHj3UsmVLDR06VDt37rS9pEZbuHChBg8erLZt26pTp04aO3asDh48GLTP+fPnlZGRoYSEBLVp00bjx4+v8UZ1zc2iRYvkcrmUmZkZGIuknCdOnNC9996rhIQExcbGqm/fvvr0008D240xmjt3rrp06aLY2FilpaXp8OHDFlccuqqqKmVnZyslJUWxsbG68sor9eSTTwZ97kVzzfnxxx/r9ttvV1JSklwul9avXx+0vT65Tp8+rUmTJikuLk7t2rXTAw88oO++++4ypqifn8vq8/k0a9Ys9e3bV61bt1ZSUpJ++9vf6uTJk0FzNIesdd2nP/bQQw/J5XIpLy8vaLw55JTql/XAgQMaPXq04uPj1bp1aw0ePFjHjh0LbA/H43HEFpI1a9YoKytL8+bN0+7du9WvXz+lp6fr1KlTtpfWKEVFRcrIyND27dtVUFAgn8+nkSNH6ty5///hSTNmzNCGDRu0du1aFRUV6eTJkxo3bpzFVTfOrl279NJLL+naa68NGo+UnN9++62GDRsmt9ut999/X/v379dzzz2n9u3bB/ZZvHixli5dqpUrV2rHjh1q3bq10tPTdf78eYsrD01ubq5WrFihF154QQcOHFBubq4WL16sZcuWBfZprjnPnTunfv36afny5bVur0+uSZMm6Z///KcKCgq0ceNGffzxx5o6derlilBvP5e1srJSu3fvVnZ2tnbv3q23335bBw8e1OjRo4P2aw5Z67pPL1q3bp22b99e69ulN4ecUt1Z//Wvf2n48OHq1auXPvroI33++efKzs5Wy5YtA/uE5fG4QZ+A0wwMGTLEZGRkBC5XVVWZpKQks3DhQourCr9Tp04ZSaaoqMgYY8yZM2eM2+02a9euDexz4MABI8kUFxfbWmaDnT171vTs2dMUFBSYG264wUyfPt0YE1k5Z82aZYYPH/6T2/1+v0lMTDTPPvtsYOzMmTPG4/GYN95443IsMSxGjRpl7r///qCxcePGmUmTJhljIienJLNu3brA5frk2r9/v5Fkdu3aFdjn/fffNy6Xy5w4ceKyrT1U1bPWZufOnUaSOXr0qDGmeWb9qZz/+c9/zBVXXGH27dtnunfvbp5//vnAtuaY05jas951113m3nvv/cnrhOvxOCKPkFy4cEElJSVKS0sLjEVFRSktLU3FxcUWVxZ+5eXlkqQOHTpIkkpKSuTz+YKy9+rVS926dWuW2TMyMjRq1KigPFJk5Xz33Xc1aNAg3XnnnerUqZMGDBigl19+ObD9yJEjKi0tDcoaHx+voUOHNqus119/vQoLC3Xo0CFJ0meffaatW7fqN7/5jaTIyVldfXIVFxerXbt2GjRoUGCftLQ0RUVFaceOHZd9zeFUXl4ul8sV+IyySMnq9/t13333aebMmerdu3eN7ZGU87333tNVV12l9PR0derUSUOHDg16Widcj8cRWUi+/vprVVVV1Xhn2M6dO6u0tNTSqsLP7/crMzNTw4YNU58+fSRJpaWlatGiRY0PKGyO2d98803t3r1bCxcurLEtknL++9//1ooVK9SzZ09t3rxZDz/8sB577DH99a9/laRAnub++zx79mzdfffd6tWrl9xutwYMGKDMzExNmjRJUuTkrK4+uUpLS9WpU6eg7TExMerQoUOzzn7+/HnNmjVL99xzT+DD2CIla25urmJiYvTYY4/Vuj1Scp46dUrfffedFi1apFtvvVUffPCB7rjjDo0bN05FRUWSwvd4fEneOh6XR0ZGhvbt26etW7faXkrYHT9+XNOnT1dBQUHQ85SRyO/3a9CgQXrmmWckSQMGDNC+ffu0cuVKTZ482fLqwuett97S66+/rvz8fPXu3Vt79+5VZmamkpKSIionfuDz+TRhwgQZY7RixQrbywmrkpIS/fnPf9bu3bvlcrlsL+eS8vv9kqQxY8ZoxowZkqT+/ftr27ZtWrlypW644Yaw3VZEHiHp2LGjoqOja5zhW1ZWpsTEREurCq9p06Zp48aN+vDDD9W1a9fAeGJioi5cuKAzZ84E7d/cspeUlOjUqVP61a9+pZiYGMXExKioqEhLly5VTEyMOnfuHBE5JalLly665pprgsauvvrqwBnsF/M099/nmTNnBo6S9O3bV/fdd59mzJgROAIWKTmrq0+uxMTEGifc/+9//9Pp06ebZfaLZeTo0aMqKCgI+qj6SMj6ySef6NSpU+rWrVvg8eno0aP6wx/+oB49ekiKjJzSD39PY2Ji6nyMCsfjcUQWkhYtWmjgwIEqLCwMjPn9fhUWFio1NdXiyhrPGKNp06Zp3bp12rJli1JSUoK2Dxw4UG63Oyj7wYMHdezYsWaV/ZZbbtEXX3yhvXv3Br4GDRqkSZMmBf47EnJK0rBhw2q8dPvQoUPq3r27JCklJUWJiYlBWSsqKrRjx45mlbWyslJRUcEPOdHR0YH/A4uUnNXVJ1dqaqrOnDmjkpKSwD5btmyR3+/X0KFDL/uaG+NiGTl8+LD+8Y9/KCEhIWh7JGS977779Pnnnwc9PiUlJWnmzJnavHmzpMjIKf3w93Tw4ME/+xgVtr87IZ6A22y8+eabxuPxmFdffdXs37/fTJ061bRr186UlpbaXlqjPPzwwyY+Pt589NFH5quvvgp8VVZWBvZ56KGHTLdu3cyWLVvMp59+alJTU01qaqrFVYfHj19lY0zk5Ny5c6eJiYkxTz/9tDl8+LB5/fXXTatWrczf/va3wD6LFi0y7dq1M++88475/PPPzZgxY0xKSor5/vvvLa48NJMnTzZXXHGF2bhxozly5Ih5++23TceOHc3jjz8e2Ke55jx79qzZs2eP2bNnj5FklixZYvbs2RN4ZUl9ct16661mwIABZseOHWbr1q2mZ8+e5p577rEV6Sf9XNYLFy6Y0aNHm65du5q9e/cGPUZ5vd7AHM0ha133aXXVX2VjTPPIaUzdWd9++23jdrvNqlWrzOHDh82yZctMdHS0+eSTTwJzhOPxOGILiTHGLFu2zHTr1s20aNHCDBkyxGzfvt32khpNUq1fq1evDuzz/fffm0ceecS0b9/etGrVytxxxx3mq6++srfoMKleSCIp54YNG0yfPn2Mx+MxvXr1MqtWrQra7vf7TXZ2tuncubPxeDzmlltuMQcPHrS02oapqKgw06dPN926dTMtW7Y0v/jFL8yf/vSnoD9UzTXnhx9+WOu/y8mTJxtj6pfrm2++Mffcc49p06aNiYuLM1OmTDFnz561kObn/VzWI0eO/ORj1IcffhiYozlkres+ra62QtIcchpTv6yvvPKK+eUvf2latmxp+vXrZ9avXx80Rzgej13G/OhtEgEAACyIyHNIAABA80IhAQAA1lFIAACAdRQSAABgHYUEAABYRyEBAADWUUgAAIB1FBIAAGAdhQQAAFhHIQEAANZRSAAAgHUUEgAAYN3/A4HVkuqYjjnMAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "address_counts.hist(bins=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0707a780",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot: >"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGdCAYAAACyzRGfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAo90lEQVR4nO3df3DUdX7H8dcGNhsCbCK/sqQkkrnjBEXhLgjs4fQU86OUc6Bk9BQ65ZA52hqpkKuWzAgEThvAKXB4Ac4rjXXaHJZr4Yo/kFw8wzAkEaL0QK85r4NCDQlVmywkl82a/fYPmz2XBMh3s/nsJjwfMzv6/exnP9/3ft8b8/K73+w6LMuyBAAAYEhCrAsAAAA3F8IHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKOGx7qAqwWDQTU2Nmr06NFyOByxLgcAAPSBZVm6fPmy0tPTlZBw/XMbcRc+GhsblZGREesyAABABC5cuKBJkyZdd07chY/Ro0dL+qJ4t9sdtXUDgYCOHj2qvLw8OZ3OqK0Le+hDfKAP8YNexAf60H8+n08ZGRmh3+PXE3fho/utFrfbHfXwkZycLLfbzQsrhuhDfKAP8YNexAf6ED19uWSCC04BAIBRhA8AAGAU4QMAABhF+AAAAEYRPgAAgFGEDwAAYBThAwAAGEX4AAAARhE+AACAUYQPAABglK3w0dXVpfXr1ysrK0sjRozQV77yFf3gBz+QZVmhOZZlacOGDZo4caJGjBihnJwcffDBB1EvHAAADE62wsfWrVu1Z88e/ehHP9Kvf/1rbd26Vdu2bdPzzz8fmrNt2zbt2rVLe/fuVV1dnUaOHKn8/Hx1dHREvXgAADD42PpiuRMnTmjRokVauHChJGny5Mn66U9/qrffflvSF2c9du7cqaefflqLFi2SJL300ktKS0vToUOH9PDDD0e5fAAAMNjYCh/f/OY39cILL+g3v/mNvva1r+k//uM/dPz4cW3fvl2SdO7cOTU1NSknJyf0mJSUFM2ZM0c1NTW9hg+/3y+/3x/a9vl8kr74hsFAIBDRk+pN91rRXBP20Yf4QB/iB72ID/Sh/+wcO1vhY926dfL5fJo6daqGDRumrq4uPfvss1q2bJkkqampSZKUlpYW9ri0tLTQfVcrLS3Vpk2beowfPXpUycnJdsrrk8rKyqivCfvoQ3ygD/GDXsQH+hC59vb2Ps+1FT7+5V/+Rf/8z/+siooK3XHHHTp9+rTWrFmj9PR0LV++3HahklRcXKyioqLQts/nU0ZGhvLy8uR2uyNaszeBQECVlZVafypB/qAjNH62JD9q+8CNdfchNzdXTqcz1uXctOhD/KAX8YE+9F/3Oxd9YSt8PPnkk1q3bl3o7ZM777xTH330kUpLS7V8+XJ5PB5JUnNzsyZOnBh6XHNzs2bOnNnrmi6XSy6Xq8e40+kckBeAP+iQv+v34YMXWWwMVH9hD32IH/QiPtCHyNk5brb+2qW9vV0JCeEPGTZsmILBoCQpKytLHo9HVVVVoft9Pp/q6urk9Xrt7AoAAAxRts58PPDAA3r22WeVmZmpO+64Q++++662b9+uRx99VJLkcDi0Zs0aPfPMM5oyZYqysrK0fv16paena/HixQNRPwAAGGRshY/nn39e69ev12OPPaZLly4pPT1df/7nf64NGzaE5jz11FNqa2vTqlWr1NLSonvuuUdHjhxRUlJS1IsHAACDj63wMXr0aO3cuVM7d+685hyHw6HNmzdr8+bN/a0NAAAMQXy3CwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADDKVviYPHmyHA5Hj1thYaEkqaOjQ4WFhRo7dqxGjRqlgoICNTc3D0jhAABgcLIVPk6ePKmLFy+GbpWVlZKkBx98UJK0du1aHT58WAcOHFB1dbUaGxu1ZMmS6FcNAAAGreF2Jo8fPz5se8uWLfrKV76ib33rW2ptbdW+fftUUVGh+fPnS5LKy8s1bdo01dbWau7cudGrGgAADFq2wseXdXZ26p/+6Z9UVFQkh8Oh+vp6BQIB5eTkhOZMnTpVmZmZqqmpuWb48Pv98vv9oW2fzydJCgQCCgQCkZbXQ/dargSr13GY0X28Oe6xRR/iB72ID/Sh/+wcu4jDx6FDh9TS0qLvfve7kqSmpiYlJiYqNTU1bF5aWpqampquuU5paak2bdrUY/zo0aNKTk6OtLxr+sGsYNj2a6+9FvV94Ma637JDbNGH+EEv4gN9iFx7e3uf50YcPvbt26cFCxYoPT090iUkScXFxSoqKgpt+3w+ZWRkKC8vT263u19rf1kgEFBlZaXWn0qQP+gIjZ8tyY/aPnBj3X3Izc2V0+mMdTk3LfoQP+hFfKAP/df9zkVfRBQ+PvroI/3iF7/Qv/3bv4XGPB6POjs71dLSEnb2o7m5WR6P55pruVwuuVyuHuNOp3NAXgD+oEP+rt+HD15ksTFQ/YU99CF+0Iv4QB8iZ+e4RfQ5H+Xl5ZowYYIWLlwYGsvOzpbT6VRVVVVorKGhQefPn5fX641kNwAAYAiyfeYjGAyqvLxcy5cv1/Dhv394SkqKVq5cqaKiIo0ZM0Zut1urV6+W1+vlL10AAECI7fDxi1/8QufPn9ejjz7a474dO3YoISFBBQUF8vv9ys/P1+7du6NSKAAAGBpsh4+8vDxZltXrfUlJSSorK1NZWVm/CwMAAEMT3+0CAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwanisC4i1yete7TH24ZaFMagEAICbA2c+AACAUYQPAABgFOEDAAAYRfgAAABGET4AAIBRhA8AAGAU4QMAABhF+AAAAEbZDh8ff/yx/vRP/1Rjx47ViBEjdOedd+rUqVOh+y3L0oYNGzRx4kSNGDFCOTk5+uCDD6JaNAAAGLxshY///d//1bx58+R0OvX666/r/fff19/93d/plltuCc3Ztm2bdu3apb1796qurk4jR45Ufn6+Ojo6ol48AAAYfGx9vPrWrVuVkZGh8vLy0FhWVlbo3y3L0s6dO/X0009r0aJFkqSXXnpJaWlpOnTokB5++OEolQ0AAAYrW+Hj3//935Wfn68HH3xQ1dXV+oM/+AM99thj+t73vidJOnfunJqampSTkxN6TEpKiubMmaOamppew4ff75ff7w9t+3w+SVIgEFAgEIjoSfWmey1XgtXnuYi+7mPLMY4t+hA/6EV8oA/9Z+fYOSzLuvFv4/+XlJQkSSoqKtKDDz6okydP6oknntDevXu1fPlynThxQvPmzVNjY6MmTpwYetxDDz0kh8Ohl19+uceaJSUl2rRpU4/xiooKJScn9/mJAACA2Glvb9fSpUvV2toqt9t93bm2wkdiYqJmzZqlEydOhMb+6q/+SidPnlRNTU1E4aO3Mx8ZGRn65JNPbli8HYFAQJWVlVp/KkH+oOO6c8+W5EdtvwjX3Yfc3Fw5nc5Yl3PTog/xg17EB/rQfz6fT+PGjetT+LD1tsvEiRN1++23h41NmzZN//qv/ypJ8ng8kqTm5uaw8NHc3KyZM2f2uqbL5ZLL5eox7nQ6B+QF4A865O+6fvjghTfwBqq/sIc+xA96ER/oQ+TsHDdbf+0yb948NTQ0hI395je/0a233irpi4tPPR6PqqqqQvf7fD7V1dXJ6/Xa2RUAABiibJ35WLt2rb75zW/qb//2b/XQQw/p7bff1gsvvKAXXnhBkuRwOLRmzRo988wzmjJlirKysrR+/Xqlp6dr8eLFA1E/AAAYZGyFj7vvvlsHDx5UcXGxNm/erKysLO3cuVPLli0LzXnqqafU1tamVatWqaWlRffcc4+OHDkSulgVAADc3GyFD0n69re/rW9/+9vXvN/hcGjz5s3avHlzvwoDAABDE9/tAgAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIyyFT5KSkrkcDjCblOnTg3d39HRocLCQo0dO1ajRo1SQUGBmpubo140AAAYvGyf+bjjjjt08eLF0O348eOh+9auXavDhw/rwIEDqq6uVmNjo5YsWRLVggEAwOA23PYDhg+Xx+PpMd7a2qp9+/apoqJC8+fPlySVl5dr2rRpqq2t1dy5c/tfLQAAGPRsh48PPvhA6enpSkpKktfrVWlpqTIzM1VfX69AIKCcnJzQ3KlTpyozM1M1NTXXDB9+v19+vz+07fP5JEmBQECBQMBuedfUvZYrwerzXERf97HlGMcWfYgf9CI+0If+s3PsHJZl3fi38f97/fXXdeXKFd122226ePGiNm3apI8//lhnz57V4cOHtWLFirAgIUmzZ8/Wfffdp61bt/a6ZklJiTZt2tRjvKKiQsnJyX1+IgAAIHba29u1dOlStba2yu12X3eurfBxtZaWFt16663avn27RowYEVH46O3MR0ZGhj755JMbFm9HIBBQZWWl1p9KkD/ouO7csyX5UdsvwnX3ITc3V06nM9bl3LToQ/ygF/GBPvSfz+fTuHHj+hQ+bL/t8mWpqan62te+pt/+9rfKzc1VZ2enWlpalJqaGprT3Nzc6zUi3Vwul1wuV49xp9M5IC8Af9Ahf9f1wwcvvIE3UP2FPfQhftCL+EAfImfnuPXrcz6uXLmi//qv/9LEiROVnZ0tp9Opqqqq0P0NDQ06f/68vF5vf3YDAACGEFtnPv76r/9aDzzwgG699VY1NjZq48aNGjZsmB555BGlpKRo5cqVKioq0pgxY+R2u7V69Wp5vV7+0gUAAITYCh///d//rUceeUSffvqpxo8fr3vuuUe1tbUaP368JGnHjh1KSEhQQUGB/H6/8vPztXv37gEpHAAADE62wsf+/fuve39SUpLKyspUVlbWr6IAAMDQxXe7AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwanisC0C4yete7TH24ZaFMagEAICBwZkPAABgFOEDAAAYRfgAAABGET4AAIBRhA8AAGAU4QMAABhF+AAAAEYRPgAAgFF8yFiUDOSHg129Nh86BgAYzDjzAQAAjCJ8AAAAowgfAADAKK756IPB+mVvXCsCAIhHnPkAAABGET4AAIBRhA8AAGAU4QMAABjVr/CxZcsWORwOrVmzJjTW0dGhwsJCjR07VqNGjVJBQYGam5v7WycAABgiIg4fJ0+e1I9//GPdddddYeNr167V4cOHdeDAAVVXV6uxsVFLlizpd6EAAGBoiCh8XLlyRcuWLdNPfvIT3XLLLaHx1tZW7du3T9u3b9f8+fOVnZ2t8vJynThxQrW1tVErGgAADF4Rfc5HYWGhFi5cqJycHD3zzDOh8fr6egUCAeXk5ITGpk6dqszMTNXU1Gju3Lk91vL7/fL7/aFtn88nSQoEAgoEApGU16vutVwJVp/ndnMN6/mYSOb0RW/rRLru1WtF83hGqruGeKjlZkYf4ge9iA/0of/sHDuHZVk3/m33Jfv379ezzz6rkydPKikpSffee69mzpypnTt3qqKiQitWrAgLE5I0e/Zs3Xfffdq6dWuP9UpKSrRp06Ye4xUVFUpOTrZTGgAAiJH29nYtXbpUra2tcrvd151r68zHhQsX9MQTT6iyslJJSUn9KrJbcXGxioqKQts+n08ZGRnKy8u7YfF2BAIBVVZWav2pBPmDjn6vd7YkP2x7eskbN5zTF72tE+m6V68VST3R1t2H3NxcOZ3OWJdz06IP8YNexAf60H/d71z0ha3wUV9fr0uXLukb3/hGaKyrq0vHjh3Tj370I73xxhvq7OxUS0uLUlNTQ3Oam5vl8Xh6XdPlcsnlcvUYdzqdA/IC8Acd8nf1P3xcXVtva0ZSf19q6+u6V68VTz9QA9Vf2EMf4ge9iA/0IXJ2jput8HH//ffrzJkzYWMrVqzQ1KlT9Td/8zfKyMiQ0+lUVVWVCgoKJEkNDQ06f/68vF6vnV0BAIAhylb4GD16tKZPnx42NnLkSI0dOzY0vnLlShUVFWnMmDFyu91avXq1vF5vrxebAgCAm0/Uv9V2x44dSkhIUEFBgfx+v/Lz87V79+5o7wYAAAxS/Q4fb731Vth2UlKSysrKVFZW1t+lAQDAEMR3uwAAAKMIHwAAwKioX/OB35u87tWw7Q+3LIxRJQAAxA/OfAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACM4kPGYuzqDyKL9ToAAAw0znwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAo4bbmbxnzx7t2bNHH374oSTpjjvu0IYNG7RgwQJJUkdHh77//e9r//798vv9ys/P1+7du5WWlhb1wgejyetejXUJPVxd04dbFsaoEgDAzcLWmY9JkyZpy5Ytqq+v16lTpzR//nwtWrRI7733niRp7dq1Onz4sA4cOKDq6mo1NjZqyZIlA1I4AAAYnGyd+XjggQfCtp999lnt2bNHtbW1mjRpkvbt26eKigrNnz9fklReXq5p06aptrZWc+fOjV7VAABg0LIVPr6sq6tLBw4cUFtbm7xer+rr6xUIBJSTkxOaM3XqVGVmZqqmpuaa4cPv98vv94e2fT6fJCkQCCgQCERaXg/da7kSrKiu1801LDrrRrLvvu6/L4+L5jG/Xg0DvR9cH32IH/QiPtCH/rNz7ByWZdn6rXnmzBl5vV51dHRo1KhRqqio0B//8R+roqJCK1asCAsSkjR79mzdd9992rp1a6/rlZSUaNOmTT3GKyoqlJycbKc0AAAQI+3t7Vq6dKlaW1vldruvO9f2mY/bbrtNp0+fVmtrq372s59p+fLlqq6ujrjY4uJiFRUVhbZ9Pp8yMjKUl5d3w+LtCAQCqqys1PpTCfIHHVFbNxbOluT3GJte8saArR1N3X3Izc2V0+kc0H3h2uhD/KAX8YE+9F/3Oxd9YTt8JCYm6qtf/aokKTs7WydPntQPf/hDfec731FnZ6daWlqUmpoamt/c3CyPx3PN9Vwul1wuV49xp9M5IC8Af9Ahf9fgDh+9HZdoPSdTP3QD1V/YQx/iB72ID/QhcnaOW78/5yMYDMrv9ys7O1tOp1NVVVWh+xoaGnT+/Hl5vd7+7gYAAAwRts58FBcXa8GCBcrMzNTly5dVUVGht956S2+88YZSUlK0cuVKFRUVacyYMXK73Vq9erW8Xi9/6QIAAEJshY9Lly7pz/7sz3Tx4kWlpKTorrvu0htvvKHc3FxJ0o4dO5SQkKCCgoKwDxkDAADoZit87Nu377r3JyUlqaysTGVlZf0qCgAADF18twsAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMInwAAACjbH23C+LD5HWvxroEAAAixpkPAABgFOEDAAAYRfgAAABGET4AAIBRhA8AAGAU4QMAABhF+AAAAEYRPgAAgFGEDwAAYBThAwAAGEX4AAAARhE+AACAUYQPAABgFOEDAAAYRfgAAABGET4AAIBRhA8AAGAU4QMAABhF+AAAAEYRPgAAgFGEDwAAYJSt8FFaWqq7775bo0eP1oQJE7R48WI1NDSEzeno6FBhYaHGjh2rUaNGqaCgQM3NzVEtGgAADF62wkd1dbUKCwtVW1uryspKBQIB5eXlqa2tLTRn7dq1Onz4sA4cOKDq6mo1NjZqyZIlUS8cAAAMTsPtTD5y5EjY9osvvqgJEyaovr5ef/iHf6jW1lbt27dPFRUVmj9/viSpvLxc06ZNU21trebOnRu9ygEAwKBkK3xcrbW1VZI0ZswYSVJ9fb0CgYBycnJCc6ZOnarMzEzV1NT0Gj78fr/8fn9o2+fzSZICgYACgUB/ygvTvZYrwYramkNRNI/59dYf6P3g+uhD/KAX8YE+9J+dYxdx+AgGg1qzZo3mzZun6dOnS5KampqUmJio1NTUsLlpaWlqamrqdZ3S0lJt2rSpx/jRo0eVnJwcaXnX9INZwaivOZS89tprRvZTWVlpZD+4PvoQP+hFfKAPkWtvb+/z3IjDR2Fhoc6ePavjx49HuoQkqbi4WEVFRaFtn8+njIwM5eXlye1292vtLwsEAqqsrNT6UwnyBx1RW3eoOVuSP6Drd/chNzdXTqdzQPeFa6MP8YNexAf60H/d71z0RUTh4/HHH9crr7yiY8eOadKkSaFxj8ejzs5OtbS0hJ39aG5ulsfj6XUtl8sll8vVY9zpdA7IC8AfdMjfRfi4FlM/dAPVX9hDH+IHvYgP9CFydo6brb92sSxLjz/+uA4ePKg333xTWVlZYfdnZ2fL6XSqqqoqNNbQ0KDz58/L6/Xa2RUAABiibJ35KCwsVEVFhX7+859r9OjRoes4UlJSNGLECKWkpGjlypUqKirSmDFj5Ha7tXr1anm9Xv7SBQAASLIZPvbs2SNJuvfee8PGy8vL9d3vfleStGPHDiUkJKigoEB+v1/5+fnavXt3VIpF/Jq87tWw7Q+3LIxRJQCAeGcrfFjWjf9MNSkpSWVlZSorK4u4KAAAMHTx3S4AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAowgfAADAKMIHAAAwivABAACMsvXdLoDU80vkAACwgzMfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIwifAAAAKMIHwAAwCjCBwAAMIrwAQAAjCJ8AAAAo/hiOYTp7UvjPtyyMGbrAACGHs58AAAAowgfAADAKMIHAAAwivABAACMInwAAACjCB8AAMAowgcAADCK8AEAAIyy/SFjx44d03PPPaf6+npdvHhRBw8e1OLFi0P3W5aljRs36ic/+YlaWlo0b9487dmzR1OmTIlm3RgCevsgsqvxwWQAMPTYPvPR1tamGTNmqKysrNf7t23bpl27dmnv3r2qq6vTyJEjlZ+fr46Ojn4XCwAABj/bZz4WLFigBQsW9HqfZVnauXOnnn76aS1atEiS9NJLLyktLU2HDh3Sww8/3L9qAQDAoBfV73Y5d+6cmpqalJOTExpLSUnRnDlzVFNT02v48Pv98vv9oW2fzydJCgQCCgQCUautey1XghW1NW8WV/fBNSyyY/jlngYCgT6tE83XAH7vy31AbNGL+EAf+s/OsXNYlhXxb2OHwxF2zceJEyc0b948NTY2auLEiaF5Dz30kBwOh15++eUea5SUlGjTpk09xisqKpScnBxpaQAAwKD29nYtXbpUra2tcrvd150b82+1LS4uVlFRUWjb5/MpIyNDeXl5NyzejkAgoMrKSq0/lSB/0BG1ddF3Z0vyQ33Izc3V1599s0+PQfR9uQ9OpzPW5dzU6EV8oA/91/3ORV9ENXx4PB5JUnNzc9iZj+bmZs2cObPXx7hcLrlcrh7jTqdzQF4A/qBD/i7CRyx8uZ9Op7NPfeA/AgNroH7OYB+9iA/0IXJ2jltUP+cjKytLHo9HVVVVoTGfz6e6ujp5vd5o7goAAAxSts98XLlyRb/97W9D2+fOndPp06c1ZswYZWZmas2aNXrmmWc0ZcoUZWVlaf369UpPTw/7LBAAAHDzsh0+Tp06pfvuuy+03X29xvLly/Xiiy/qqaeeUltbm1atWqWWlhbdc889OnLkiJKSkqJXNTAAevvQMz7kDACiz3b4uPfee3W9P5BxOBzavHmzNm/e3K/CAADA0MR3uwAAAKMIHwAAwKiYf84HcD1chwEAQw9nPgAAgFGEDwAAYBThAwAAGMU1Hxj0ersu5GpcJwIA8YMzHwAAwCjCBwAAMIrwAQAAjCJ8AAAAo7jgFMZMXveqXMMsbZstTS95Q5Ij4nWi8ZhoXYR69dpc3AoA18eZDwAAYBThAwAAGEX4AAAARnHNB25a0bp2BABgD2c+AACAUYQPAABgFOEDAAAYRfgAAABGccEpEGV8yy4AXB9nPgAAgFGEDwAAYBThAwAAGMU1H8B1DNSHikW6LteKABgKOPMBAACMInwAAACjCB8AAMAorvkAhpi+XE/ywQ/ybviYvlxfcvXjentMtOaYFG/1AEMNZz4AAIBRhA8AAGAU4QMAABhF+AAAAEYN2AWnZWVleu6559TU1KQZM2bo+eef1+zZswdqd8BNIVofeja95A1tm/3FP/1djqis2VfReg7Rukg2WvuKtJ5ImbwoNpKLhnszGC7cvdHPxGB4Dlcz/drsiwE58/Hyyy+rqKhIGzdu1DvvvKMZM2YoPz9fly5dGojdAQCAQWRAwsf27dv1ve99TytWrNDtt9+uvXv3Kjk5Wf/wD/8wELsDAACDSNTfduns7FR9fb2Ki4tDYwkJCcrJyVFNTU2P+X6/X36/P7Td2toqSfrss88UCASiVlcgEFB7e7uGBxLUFTR7mhm/Nzxoqb09SB9irC99+PTTT2+8zudtN3zM1XP6IpJ99+dxkbh6X5HW0/3fpk8//VROp7PP++/LsY+WaPV5IGvsr77+jojn53Atkb427bp8+bIkybKsG0+2ouzjjz+2JFknTpwIG3/yySet2bNn95i/ceNGSxI3bty4cePGbQjcLly4cMOsEPNPOC0uLlZRUVFoOxgM6rPPPtPYsWPlcETv/4x9Pp8yMjJ04cIFud3uqK0Le+hDfKAP8YNexAf60H+WZeny5ctKT0+/4dyoh49x48Zp2LBham5uDhtvbm6Wx+PpMd/lcsnlcoWNpaamRrusELfbzQsrDtCH+EAf4ge9iA/0oX9SUlL6NC/qF5wmJiYqOztbVVVVobFgMKiqqip5vd5o7w4AAAwyA/K2S1FRkZYvX65Zs2Zp9uzZ2rlzp9ra2rRixYqB2B0AABhEBiR8fOc739H//M//aMOGDWpqatLMmTN15MgRpaWlDcTu+sTlcmnjxo093uKBWfQhPtCH+EEv4gN9MMthWX35mxgAAIDo4LtdAACAUYQPAABgFOEDAAAYRfgAAABG3RTho6ysTJMnT1ZSUpLmzJmjt99+O9YlDTnHjh3TAw88oPT0dDkcDh06dCjsfsuytGHDBk2cOFEjRoxQTk6OPvjgg7A5n332mZYtWya3263U1FStXLlSV65cMfgsBrfS0lLdfffdGj16tCZMmKDFixeroaEhbE5HR4cKCws1duxYjRo1SgUFBT0+EPD8+fNauHChkpOTNWHCBD355JP6/PPPTT6VQW/Pnj266667Qh9Y5fV69frrr4fupw/mbdmyRQ6HQ2vWrAmN0YfYGfLh4+WXX1ZRUZE2btyod955RzNmzFB+fr4uXboU69KGlLa2Ns2YMUNlZWW93r9t2zbt2rVLe/fuVV1dnUaOHKn8/Hx1dHSE5ixbtkzvvfeeKisr9corr+jYsWNatWqVqacw6FVXV6uwsFC1tbWqrKxUIBBQXl6e2tp+/6VSa9eu1eHDh3XgwAFVV1ersbFRS5YsCd3f1dWlhQsXqrOzUydOnNA//uM/6sUXX9SGDRti8ZQGrUmTJmnLli2qr6/XqVOnNH/+fC1atEjvvfeeJPpg2smTJ/XjH/9Yd911V9g4fYihqHybXBybPXu2VVhYGNru6uqy0tPTrdLS0hhWNbRJsg4ePBjaDgaDlsfjsZ577rnQWEtLi+Vyuayf/vSnlmVZ1vvvv29Jsk6ePBma8/rrr1sOh8P6+OOPjdU+lFy6dMmSZFVXV1uW9cUxdzqd1oEDB0Jzfv3rX1uSrJqaGsuyLOu1116zEhISrKamptCcPXv2WG632/L7/WafwBBzyy23WH//939PHwy7fPmyNWXKFKuystL61re+ZT3xxBOWZfHzEGtD+sxHZ2en6uvrlZOTExpLSEhQTk6OampqYljZzeXcuXNqamoK60NKSormzJkT6kNNTY1SU1M1a9as0JycnBwlJCSorq7OeM1DQWtrqyRpzJgxkqT6+noFAoGwPkydOlWZmZlhfbjzzjvDPhAwPz9fPp8v9H/tsKerq0v79+9XW1ubvF4vfTCssLBQCxcuDDveEj8PsRbzb7UdSJ988om6urp6fLJqWlqa/vM//zNGVd18mpqaJKnXPnTf19TUpAkTJoTdP3z4cI0ZMyY0B30XDAa1Zs0azZs3T9OnT5f0xTFOTEzs8cWNV/ehtz5134e+O3PmjLxerzo6OjRq1CgdPHhQt99+u06fPk0fDNm/f7/eeecdnTx5ssd9/DzE1pAOH8DNqrCwUGfPntXx48djXcpN67bbbtPp06fV2tqqn/3sZ1q+fLmqq6tjXdZN48KFC3riiSdUWVmppKSkWJeDqwzpt13GjRunYcOG9bh6ubm5WR6PJ0ZV3Xy6j/X1+uDxeHpcBPz555/rs88+o1c2Pf7443rllVf0y1/+UpMmTQqNezwedXZ2qqWlJWz+1X3orU/d96HvEhMT9dWvflXZ2dkqLS3VjBkz9MMf/pA+GFJfX69Lly7pG9/4hoYPH67hw4erurpau3bt0vDhw5WWlkYfYmhIh4/ExERlZ2erqqoqNBYMBlVVVSWv1xvDym4uWVlZ8ng8YX3w+Xyqq6sL9cHr9aqlpUX19fWhOW+++aaCwaDmzJljvObByLIsPf744zp48KDefPNNZWVlhd2fnZ0tp9MZ1oeGhgadP38+rA9nzpwJC4KVlZVyu926/fbbzTyRISoYDMrv99MHQ+6//36dOXNGp0+fDt1mzZqlZcuWhf6dPsRQrK94HWj79++3XC6X9eKLL1rvv/++tWrVKis1NTXs6mX03+XLl613333Xevfddy1J1vbt2613333X+uijjyzLsqwtW7ZYqamp1s9//nPrV7/6lbVo0SIrKyvL+t3vfhda44/+6I+sr3/961ZdXZ11/Phxa8qUKdYjjzwSq6c06PzlX/6llZKSYr311lvWxYsXQ7f29vbQnL/4i7+wMjMzrTfffNM6deqU5fV6La/XG7r/888/t6ZPn27l5eVZp0+fto4cOWKNHz/eKi4ujsVTGrTWrVtnVVdXW+fOnbN+9atfWevWrbMcDod19OhRy7LoQ6x8+a9dLIs+xNKQDx+WZVnPP/+8lZmZaSUmJlqzZ8+2amtrY13SkPPLX/7SktTjtnz5csuyvvhz2/Xr11tpaWmWy+Wy7r//fquhoSFsjU8//dR65JFHrFGjRllut9tasWKFdfny5Rg8m8Gpt+MvySovLw/N+d3vfmc99thj1i233GIlJydbf/Inf2JdvHgxbJ0PP/zQWrBggTVixAhr3Lhx1ve//30rEAgYfjaD26OPPmrdeuutVmJiojV+/Hjr/vvvDwUPy6IPsXJ1+KAPseOwLMuKzTkXAABwMxrS13wAAID4Q/gAAABGET4AAIBRhA8AAGAU4QMAABhF+AAAAEYRPgAAgFGEDwAAYBThAwAAGEX4AAAARhE+AACAUYQPAABg1P8BtwGyBDMnPOYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df_state_table.zipcode.value_counts().hist(bins=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "adbb2aeb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1      55\n",
+       "2      36\n",
+       "21     29\n",
+       "3      27\n",
+       "17     26\n",
+       "       ..\n",
+       "78      1\n",
+       "61      1\n",
+       "76      1\n",
+       "73      1\n",
+       "155     1\n",
+       "Name: address, Length: 93, dtype: int64"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 55 zipcodes with only one address\n",
+    "# 1 zipcode with 155 addresses\n",
+    "address_counts.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b8ba04e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2      18\n",
+       "3      18\n",
+       "7      18\n",
+       "9      17\n",
+       "1      16\n",
+       "       ..\n",
+       "153     1\n",
+       "157     1\n",
+       "159     1\n",
+       "160     1\n",
+       "460     1\n",
+       "Name: zipcode, Length: 183, dtype: int64"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 18 zipcodes occurring in only 2 rows\n",
+    "# 1 zipcode occurring in 460 rows\n",
+    "df_state_table.zipcode.value_counts().value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1eb1004",
+   "metadata": {},
+   "source": [
+    "# Write a function to clean non-standard zipcodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "12145027",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12102      cp 33440\n",
+       "14637       cp34110\n",
+       "16971       cp33415\n",
+       "16972       cp33415\n",
+       "16973       cp33415\n",
+       "16974       cp33415\n",
+       "23973    32223-1647\n",
+       "23974    32223-1647\n",
+       "27551      cp 33433\n",
+       "27552      cp 33433\n",
+       "27553      cp 33433\n",
+       "27554      cp 33433\n",
+       "27555      cp 33433\n",
+       "29098       cp32095\n",
+       "29099       cp32095\n",
+       "29100       cp32095\n",
+       "40350      cp 33409\n",
+       "40351      cp 33409\n",
+       "46411       cp34714\n",
+       "46412       cp34714\n",
+       "46413       cp34714\n",
+       "Name: zipcode, dtype: object"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_state_table.loc[~df_state_table.zipcode.str.isdigit(), 'zipcode']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "a17b002c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12102         33440\n",
+       "14637         34110\n",
+       "16971         33415\n",
+       "16972         33415\n",
+       "16973         33415\n",
+       "16974         33415\n",
+       "23973    32223-1647\n",
+       "23974    32223-1647\n",
+       "27551         33433\n",
+       "27552         33433\n",
+       "27553         33433\n",
+       "27554         33433\n",
+       "27555         33433\n",
+       "29098         32095\n",
+       "29099         32095\n",
+       "29100         32095\n",
+       "40350         33409\n",
+       "40351         33409\n",
+       "46411         34714\n",
+       "46412         34714\n",
+       "46413         34714\n",
+       "Name: zipcode, dtype: object"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zipcodes = df_state_table.zipcode\n",
+    "all_digits = zipcodes.str.isdigit()\n",
+    "zipcodes.loc[~all_digits].str.strip('cp ') # Don't forget the space!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "1b591417",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12102    cp 33440\n",
+       "14637     cp34110\n",
+       "16971     cp33415\n",
+       "16972     cp33415\n",
+       "16973     cp33415\n",
+       "16974     cp33415\n",
+       "23973       32223\n",
+       "23974       32223\n",
+       "27551    cp 33433\n",
+       "27552    cp 33433\n",
+       "27553    cp 33433\n",
+       "27554    cp 33433\n",
+       "27555    cp 33433\n",
+       "29098     cp32095\n",
+       "29099     cp32095\n",
+       "29100     cp32095\n",
+       "40350    cp 33409\n",
+       "40351    cp 33409\n",
+       "46411     cp34714\n",
+       "46412     cp34714\n",
+       "46413     cp34714\n",
+       "Name: zipcode, dtype: object"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zipcodes[~all_digits].str.replace('-\\d{4}', '', regex=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "374ce476",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0        34601\n",
+       "1        34698\n",
+       "2        34698\n",
+       "3        34698\n",
+       "4        32003\n",
+       "         ...  \n",
+       "49995    33919\n",
+       "49996    33021\n",
+       "49997    32968\n",
+       "49998    33919\n",
+       "49999    32968\n",
+       "Name: zipcode, Length: 50000, dtype: object"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def clean_zipcode(zipcode):\n",
+    "    clean_zipcode = (\n",
+    "        zipcode\n",
+    "        .str.strip('cp ')\n",
+    "        .str.replace(r'-\\d{4}', '', regex=True)\n",
+    "    )\n",
+    "    return clean_zipcode\n",
+    "clean_zips = clean_zipcode(zipcodes)\n",
+    "clean_zips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "8a3aa3ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12102    33440\n",
+       "14637    34110\n",
+       "16971    33415\n",
+       "16972    33415\n",
+       "16973    33415\n",
+       "16974    33415\n",
+       "23973    32223\n",
+       "23974    32223\n",
+       "27551    33433\n",
+       "27552    33433\n",
+       "27553    33433\n",
+       "27554    33433\n",
+       "27555    33433\n",
+       "29098    32095\n",
+       "29099    32095\n",
+       "29100    32095\n",
+       "40350    33409\n",
+       "40351    33409\n",
+       "46411    34714\n",
+       "46412    34714\n",
+       "46413    34714\n",
+       "Name: zipcode, dtype: object"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clean_zips.loc[~all_digits]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ff2f4dc",
+   "metadata": {},
+   "source": [
+    "## Check that cleaned zips are all 5-digit strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "42e22dc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clean_zips.str.isdigit().all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "c43206dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(clean_zips.str.len() == 5).all()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73fd29fa",
+   "metadata": {},
+   "source": [
+    "# Look at employer addresses and zipcodes\n",
+    "\n",
+    "It looks like every employer address is also a residential address, for some reason. And there are not many employer addresses compared to residential addresses. So there's no point in trying to include employer addresses and zipcodes in our data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "34785bad",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20449"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_state_table.address.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "373aa8c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "246"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_state_table.employer_address.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "2273d835",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "207"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_state_table.employer_zipcode.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "2f1c034a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'NA'}"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zips = set(df_state_table.zipcode)\n",
+    "emp_zips = set(df_state_table.employer_zipcode)\n",
+    "emp_zips - zips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "9a4e118b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'NA'}"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Why are all the employer addresses equal to residential addresses???\n",
+    "addresses = set(df_state_table.address)\n",
+    "emp_addresses = set(df_state_table.employer_address)\n",
+    "emp_addresses - addresses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "3c7f7c30",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20204"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(addresses - emp_addresses)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "7cc3e507",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "employer_zipcode\n",
+       "32003    1\n",
+       "33610    1\n",
+       "33612    1\n",
+       "33614    1\n",
+       "33615    1\n",
+       "        ..\n",
+       "34287    3\n",
+       "34293    3\n",
+       "33928    3\n",
+       "34231    3\n",
+       "32218    4\n",
+       "Name: employer_address, Length: 207, dtype: int64"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "emp_address_counts = (\n",
+    "    df_state_table\n",
+    "    .groupby('employer_zipcode')\n",
+    "    ['employer_address'].nunique()\n",
+    "    .sort_values()\n",
+    ")\n",
+    "emp_address_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "c7d4806e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot: >"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAigAAAGdCAYAAAA44ojeAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAmBUlEQVR4nO3dfXBU1f3H8c+GbDamTcCAIckYHkQFqwICksY6GoQQAoMy0iqCFpWCOuBIMlWhI5Lgb4ZoLVptWnRaoK2kqB3BioouIMSHQHkww8M4jKH4VEgoULIkqetC7u8PJ9uGhORe3Js9m7xfM3eGe+/Zc8795mTy4e6Tx7IsSwAAAAaJi/YEAAAAzkZAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYJz7aEzgfTU1NOnz4sJKTk+XxeKI9HQAAYINlWTp16pQyMzMVF9f+PZKYDCiHDx9WVlZWtKcBAADOw5dffqmLL7643TYxGVCSk5MlfXuBKSkpEe07FArp3Xff1fjx4+X1eiPad1dDreyjVvZRK/uolX3Uyhm36hUIBJSVlRX+O96emAwozU/rpKSkuBJQkpKSlJKSwiLuALWyj1rZR63so1b2UStn3K6XnZdn8CJZAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOPER3sCprqq+B0Fz3T8ddCm+Kx0UrSnAABAxHAHBQAAGMdxQKmoqNDkyZOVmZkpj8ejdevWtTjv8Xja3H75y1+G2wwYMKDV+dLS0u98MQAAoGtwHFAaGho0bNgwlZWVtXn+yJEjLbYVK1bI4/Fo6tSpLdotWbKkRbsHH3zw/K4AAAB0OY5fg1JQUKCCgoJznk9PT2+x//rrr2vMmDG65JJLWhxPTk5u1RYAAEBy+UWytbW1evPNN/XHP/6x1bnS0lI98cQT6tevn6ZPn67CwkLFx7c9nWAwqGAwGN4PBAKSpFAopFAoFNE5N/fni7Mi2q/bIl0HJ2NGY+xYQ63so1b2USv7qJUzbtXLSX8ey7LO+y+xx+PR2rVrNWXKlDbPP/XUUyotLdXhw4eVmJgYPr5s2TKNGDFCqamp+uijj7Rw4ULdc889WrZsWZv9FBcXq6SkpNXx8vJyJSUlne/0AQBAJ2psbNT06dNVV1enlJSUdtu6GlCGDBmivLw8Pf/88+32s2LFCt13332qr6+Xz+drdb6tOyhZWVk6duxYhxfoVCgUkt/v16KdcQo2xc7bjPcV53f6mM21ysvLk9fr7fTxYwm1so9a2Uet7KNWzrhVr0AgoD59+tgKKK49xfP+++/rwIEDevnllztsm52drdOnT+uzzz7T4MGDW533+XxtBhev1+vaQgs2eWLqc1Ci+Qvn5s+hq6FW9lEr+6iVfdTKmUjXy0lfrn0Oyh/+8AeNHDlSw4YN67BtVVWV4uLilJaW5tZ0AABADHF8B6W+vl7V1dXh/UOHDqmqqkqpqanq16+fpG9v4bz66qv61a9+1erxlZWV2r59u8aMGaPk5GRVVlaqsLBQd955py688MLvcCkAAKCrcBxQdu7cqTFjxoT3i4qKJEkzZ87UqlWrJElr1qyRZVm64447Wj3e5/NpzZo1Ki4uVjAY1MCBA1VYWBjuBwAAwHFAyc3NVUevq50zZ47mzJnT5rkRI0Zo27ZtTocFAADdCN/FAwAAjENAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcxwGloqJCkydPVmZmpjwej9atW9fi/N133y2Px9NimzBhQos2J06c0IwZM5SSkqJevXpp1qxZqq+v/04XAgAAug7HAaWhoUHDhg1TWVnZOdtMmDBBR44cCW9/+ctfWpyfMWOG9u/fL7/fr/Xr16uiokJz5sxxPnsAANAlxTt9QEFBgQoKCtpt4/P5lJ6e3ua5Tz75RBs2bNCOHTs0atQoSdLzzz+viRMn6umnn1ZmZqbTKQEAgC7GldegbNmyRWlpaRo8eLAeeOABHT9+PHyusrJSvXr1CocTSRo3bpzi4uK0fft2N6YDAABijOM7KB2ZMGGCbr31Vg0cOFAHDx7UL37xCxUUFKiyslI9evRQTU2N0tLSWk4iPl6pqamqqalps89gMKhgMBjeDwQCkqRQKKRQKBTR+Tf354uzItqv2yJdBydjRmPsWEOt7KNW9lEr+6iVM27Vy0l/EQ8o06ZNC//76quv1tChQzVo0CBt2bJFY8eOPa8+ly5dqpKSklbH3333XSUlJZ33XNvzxKgmV/p1y1tvvRW1sf1+f9TGjjXUyj5qZR+1so9aORPpejU2NtpuG/GAcrZLLrlEffr0UXV1tcaOHav09HQdPXq0RZvTp0/rxIkT53zdysKFC1VUVBTeDwQCysrK0vjx45WSkhLR+YZCIfn9fi3aGadgkyeifbtpX3F+p4/ZXKu8vDx5vd5OHz+WUCv7qJV91Mo+auWMW/VqfgbEDtcDyldffaXjx48rIyNDkpSTk6OTJ09q165dGjlypCRp8+bNampqUnZ2dpt9+Hw++Xy+Vse9Xq9rCy3Y5FHwTOwElGj+wrn5c+hqqJV91Mo+amUftXIm0vVy0pfjgFJfX6/q6urw/qFDh1RVVaXU1FSlpqaqpKREU6dOVXp6ug4ePKhHHnlEl156qfLzv/0f/hVXXKEJEyZo9uzZWr58uUKhkObNm6dp06bxDh4AACDpPN7Fs3PnTl1zzTW65pprJElFRUW65ppr9Pjjj6tHjx7as2ePbr75Zl1++eWaNWuWRo4cqffff7/FHZDVq1dryJAhGjt2rCZOnKjrr79eL774YuSuCgAAxDTHd1Byc3NlWed+h8s777zTYR+pqakqLy93OjQAAOgm+C4eAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEcB5SKigpNnjxZmZmZ8ng8WrduXfhcKBTSo48+qquvvlrf+973lJmZqZ/+9Kc6fPhwiz4GDBggj8fTYistLf3OFwMAALoGxwGloaFBw4YNU1lZWatzjY2N2r17txYtWqTdu3frtdde04EDB3TzzTe3artkyRIdOXIkvD344IPndwUAAKDLiXf6gIKCAhUUFLR5rmfPnvL7/S2O/eY3v9Ho0aP1xRdfqF+/fuHjycnJSk9Pdzo8AADoBhwHFKfq6urk8XjUq1evFsdLS0v1xBNPqF+/fpo+fboKCwsVH9/2dILBoILBYHg/EAhI+vYppVAoFNH5Nvfni7Mi2q/bIl0HJ2NGY+xYQ63so1b2USv7qJUzbtXLSX8ey7LO+y+xx+PR2rVrNWXKlDbPf/311/rRj36kIUOGaPXq1eHjy5Yt04gRI5SamqqPPvpICxcu1D333KNly5a12U9xcbFKSkpaHS8vL1dSUtL5Th8AAHSixsZGTZ8+XXV1dUpJSWm3rWsBJRQKaerUqfrqq6+0ZcuWdieyYsUK3Xfffaqvr5fP52t1vq07KFlZWTp27FiHF+hUKBSS3+/Xop1xCjZ5Itq3m/YV53f6mM21ysvLk9fr7fTxYwm1so9a2Uet7KNWzrhVr0AgoD59+tgKKK48xRMKhXTbbbfp888/1+bNmzucRHZ2tk6fPq3PPvtMgwcPbnXe5/O1GVy8Xq9rCy3Y5FHwTOwElGj+wrn5c+hqqJV91Mo+amUftXIm0vVy0lfEA0pzOPn000/13nvvqXfv3h0+pqqqSnFxcUpLS4v0dAAAQAxyHFDq6+tVXV0d3j906JCqqqqUmpqqjIwM/fjHP9bu3bu1fv16nTlzRjU1NZKk1NRUJSQkqLKyUtu3b9eYMWOUnJysyspKFRYW6s4779SFF14YuSsDAAAxy3FA2blzp8aMGRPeLyoqkiTNnDlTxcXF+tvf/iZJGj58eIvHvffee8rNzZXP59OaNWtUXFysYDCogQMHqrCwMNwPAACA44CSm5ur9l5X29FrbkeMGKFt27Y5HRYAAHQjfBcPAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEcB5SKigpNnjxZmZmZ8ng8WrduXYvzlmXp8ccfV0ZGhi644AKNGzdOn376aYs2J06c0IwZM5SSkqJevXpp1qxZqq+v/04XAgAAug7HAaWhoUHDhg1TWVlZm+efeuopPffcc1q+fLm2b9+u733ve8rPz9fXX38dbjNjxgzt379ffr9f69evV0VFhebMmXP+VwEAALqUeKcPKCgoUEFBQZvnLMvSs88+q8cee0y33HKLJOlPf/qT+vbtq3Xr1mnatGn65JNPtGHDBu3YsUOjRo2SJD3//POaOHGinn76aWVmZn6HywEAAF1BRF+DcujQIdXU1GjcuHHhYz179lR2drYqKyslSZWVlerVq1c4nEjSuHHjFBcXp+3bt0dyOgAAIEY5voPSnpqaGklS3759Wxzv27dv+FxNTY3S0tJaTiI+XqmpqeE2ZwsGgwoGg+H9QCAgSQqFQgqFQhGbf3OfkuSLsyLar9siXQcnY0Zj7FhDreyjVvZRK/uolTNu1ctJfxENKG5ZunSpSkpKWh1/9913lZSU5MqYT4xqcqVft7z11ltRG9vv90dt7FhDreyjVvZRK/uolTORrldjY6PtthENKOnp6ZKk2tpaZWRkhI/X1tZq+PDh4TZHjx5t8bjTp0/rxIkT4cefbeHChSoqKgrvBwIBZWVlafz48UpJSYnkJSgUCsnv92vRzjgFmzwR7dtN+4rzO33M5lrl5eXJ6/V2+vixhFrZR63so1b2UStn3KpX8zMgdkQ0oAwcOFDp6enatGlTOJAEAgFt375dDzzwgCQpJydHJ0+e1K5duzRy5EhJ0ubNm9XU1KTs7Ow2+/X5fPL5fK2Oe71e1xZasMmj4JnYCSjR/IVz8+fQ1VAr+6iVfdTKPmrlTKTr5aQvxwGlvr5e1dXV4f1Dhw6pqqpKqamp6tevn+bPn6//+7//02WXXaaBAwdq0aJFyszM1JQpUyRJV1xxhSZMmKDZs2dr+fLlCoVCmjdvnqZNm8Y7eAAAgKTzCCg7d+7UmDFjwvvNT73MnDlTq1at0iOPPKKGhgbNmTNHJ0+e1PXXX68NGzYoMTEx/JjVq1dr3rx5Gjt2rOLi4jR16lQ999xzEbgcAADQFTgOKLm5ubKsc7/DxePxaMmSJVqyZMk526Smpqq8vNzp0AAAoJvgu3gAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxol4QBkwYIA8Hk+rbe7cuZKk3NzcVufuv//+SE8DAADEsPhId7hjxw6dOXMmvL9v3z7l5eXpJz/5SfjY7NmztWTJkvB+UlJSpKcBAABiWMQDykUXXdRiv7S0VIMGDdKNN94YPpaUlKT09PRIDw0AALqIiAeU//XNN9/opZdeUlFRkTweT/j46tWr9dJLLyk9PV2TJ0/WokWL2r2LEgwGFQwGw/uBQECSFAqFFAqFIjrn5v58cVZE+3VbpOvgZMxojB1rqJV91Mo+amUftXLGrXo56c9jWZZrf4lfeeUVTZ8+XV988YUyMzMlSS+++KL69++vzMxM7dmzR48++qhGjx6t11577Zz9FBcXq6SkpNXx8vJynh4CACBGNDY2avr06aqrq1NKSkq7bV0NKPn5+UpISNAbb7xxzjabN2/W2LFjVV1drUGDBrXZpq07KFlZWTp27FiHF+hUKBSS3+/Xop1xCjZ5On6AIfYV53f6mM21ysvLk9fr7fTxYwm1so9a2Uet7KNWzrhVr0AgoD59+tgKKK49xfP5559r48aN7d4ZkaTs7GxJajeg+Hw++Xy+Vse9Xq9rCy3Y5FHwTOwElGj+wrn5c+hqqJV91Mo+amUftXIm0vVy0pdrn4OycuVKpaWladKkSe22q6qqkiRlZGS4NRUAABBjXLmD0tTUpJUrV2rmzJmKj//vEAcPHlR5ebkmTpyo3r17a8+ePSosLNQNN9ygoUOHujEVAAAQg1wJKBs3btQXX3yhe++9t8XxhIQEbdy4Uc8++6waGhqUlZWlqVOn6rHHHnNjGgAAIEa5ElDGjx+vtl57m5WVpa1bt7oxJAAA6EL4Lh4AAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxiGgAAAA40Q8oBQXF8vj8bTYhgwZEj7/9ddfa+7cuerdu7e+//3va+rUqaqtrY30NAAAQAxz5Q7KlVdeqSNHjoS3Dz74IHyusLBQb7zxhl599VVt3bpVhw8f1q233urGNAAAQIyKd6XT+Hilp6e3Ol5XV6c//OEPKi8v10033SRJWrlypa644gpt27ZNP/zhD92YDgAAiDGuBJRPP/1UmZmZSkxMVE5OjpYuXap+/fpp165dCoVCGjduXLjtkCFD1K9fP1VWVp4zoASDQQWDwfB+IBCQJIVCIYVCoYjOvbk/X5wV0X7dFuk6OBkzGmPHGmplH7Wyj1rZR62ccateTvrzWJYV0b/Eb7/9turr6zV48GAdOXJEJSUl+uc//6l9+/bpjTfe0D333NMibEjS6NGjNWbMGD355JNt9llcXKySkpJWx8vLy5WUlBTJ6QMAAJc0NjZq+vTpqqurU0pKSrttIx5Qznby5En1799fy5Yt0wUXXHBeAaWtOyhZWVk6duxYhxfoVCgUkt/v16KdcQo2eSLat5v2Fed3+pjNtcrLy5PX6+308WMJtbKPWtlHreyjVs64Va9AIKA+ffrYCiiuPMXzv3r16qXLL79c1dXVysvL0zfffKOTJ0+qV69e4Ta1tbVtvmalmc/nk8/na3Xc6/W6ttCCTR4Fz8ROQInmL5ybP4euhlrZR63so1b2UStnIl0vJ325/jko9fX1OnjwoDIyMjRy5Eh5vV5t2rQpfP7AgQP64osvlJOT4/ZUAABAjIj4HZSf//znmjx5svr376/Dhw9r8eLF6tGjh+644w717NlTs2bNUlFRkVJTU5WSkqIHH3xQOTk5vIMHAACERTygfPXVV7rjjjt0/PhxXXTRRbr++uu1bds2XXTRRZKkZ555RnFxcZo6daqCwaDy8/P129/+NtLTAAAAMSziAWXNmjXtnk9MTFRZWZnKysoiPTQAAOgi+C4eAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIxDQAEAAMYhoAAAAOMQUAAAgHEiHlCWLl2qa6+9VsnJyUpLS9OUKVN04MCBFm1yc3Pl8XhabPfff3+kpwIAAGJUxAPK1q1bNXfuXG3btk1+v1+hUEjjx49XQ0NDi3azZ8/WkSNHwttTTz0V6akAAIAYFR/pDjds2NBif9WqVUpLS9OuXbt0ww03hI8nJSUpPT090sMDAIAuIOIB5Wx1dXWSpNTU1BbHV69erZdeeknp6emaPHmyFi1apKSkpDb7CAaDCgaD4f1AICBJCoVCCoVCEZ1vc3++OCui/bot0nVwMmY0xo411Mo+amUftbKPWjnjVr2c9OexLMu1v8RNTU26+eabdfLkSX3wwQfh4y+++KL69++vzMxM7dmzR48++qhGjx6t1157rc1+iouLVVJS0up4eXn5OUMNAAAwS2Njo6ZPn666ujqlpKS029bVgPLAAw/o7bff1gcffKCLL774nO02b96ssWPHqrq6WoMGDWp1vq07KFlZWTp27FiHF+hUKBSS3+/Xop1xCjZ5Itq3m/YV53f6mM21ysvLk9fr7fTxYwm1so9a2Uet7KNWzrhVr0AgoD59+tgKKK49xTNv3jytX79eFRUV7YYTScrOzpakcwYUn88nn8/X6rjX63VtoQWbPAqeiZ2AEs1fODd/Dl0NtbKPWtlHreyjVs5Eul5O+op4QLEsSw8++KDWrl2rLVu2aODAgR0+pqqqSpKUkZER6ekAAIAYFPGAMnfuXJWXl+v1119XcnKyampqJEk9e/bUBRdcoIMHD6q8vFwTJ05U7969tWfPHhUWFuqGG27Q0KFDIz0dAAAQgyIeUH73u99J+vbD2P7XypUrdffddyshIUEbN27Us88+q4aGBmVlZWnq1Kl67LHHIj0VAAAQo1x5iqc9WVlZ2rp1a6SHBQAAXQjfxQMAAIxDQAEAAMYhoAAAAOO4/lH3QFcyYMGb5/U4Xw9LT42Wrip+p9M/X+ez0kmdOh4ARAJ3UAAAgHEIKAAAwDgEFAAAYBwCCgAAMA4BBQAAGIeAAgAAjENAAQAAxiGgAAAA4xBQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABiHgAIAAIwTH+0JAEBXMGDBm50+pq+HpadGS1cVv6PgGY/jx39WOsmFWQGRwR0UAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADAOAQUAABgnqgGlrKxMAwYMUGJiorKzs/X3v/89mtMBAACGiFpAefnll1VUVKTFixdr9+7dGjZsmPLz83X06NFoTQkAABgiat9mvGzZMs2ePVv33HOPJGn58uV68803tWLFCi1YsCBa0wIAIKKi8U3X31XzN2VHU1QCyjfffKNdu3Zp4cKF4WNxcXEaN26cKisrW7UPBoMKBoPh/bq6OknSiRMnFAqFIjq3UCikxsZGxYfidKbJ+deXR8vx48c7fczmWh0/flxer7fTx4+G+NMN5/e4JkuNjU1RWVfRWBvfRayuq/NdG99pzO+4rmJtbXwX0VxX0Vgb31Xz2op0vU6dOiVJsiyr48ZWFPzzn/+0JFkfffRRi+MPP/ywNXr06FbtFy9ebEliY2NjY2Nj6wLbl19+2WFWiNpTPE4sXLhQRUVF4f2mpiadOHFCvXv3lscT2f+NBgIBZWVl6csvv1RKSkpE++5qqJV91Mo+amUftbKPWjnjVr0sy9KpU6eUmZnZYduoBJQ+ffqoR48eqq2tbXG8trZW6enprdr7fD75fL4Wx3r16uXmFJWSksIitola2Uet7KNW9lEr+6iVM27Uq2fPnrbaReVdPAkJCRo5cqQ2bdoUPtbU1KRNmzYpJycnGlMCAAAGidpTPEVFRZo5c6ZGjRql0aNH69lnn1VDQ0P4XT0AAKD7ilpAuf322/Wvf/1Ljz/+uGpqajR8+HBt2LBBffv2jdaUJH37dNLixYtbPaWE1qiVfdTKPmplH7Wyj1o5Y0K9PJZl570+AAAAnYfv4gEAAMYhoAAAAOMQUAAAgHEIKAAAwDjdKqBUVFRo8uTJyszMlMfj0bp16zp8zJYtWzRixAj5fD5deumlWrVqlevzNIHTWm3ZskUej6fVVlNT0zkTjqKlS5fq2muvVXJystLS0jRlyhQdOHCgw8e9+uqrGjJkiBITE3X11Vfrrbfe6oTZRtf51GrVqlWt1lViYmInzTh6fve732no0KHhD8rKycnR22+/3e5juuOaaua0Xt11XZ2ttLRUHo9H8+fPb7ddNNZWtwooDQ0NGjZsmMrKymy1P3TokCZNmqQxY8aoqqpK8+fP189+9jO98847Ls80+pzWqtmBAwd05MiR8JaWlubSDM2xdetWzZ07V9u2bZPf71coFNL48ePV0HDuLwj76KOPdMcdd2jWrFn6+OOPNWXKFE2ZMkX79u3rxJl3vvOplfTtp1n+77r6/PPPO2nG0XPxxRertLRUu3bt0s6dO3XTTTfplltu0f79+9ts313XVDOn9ZK657r6Xzt27NALL7ygoUOHttsuamsrMl//F3skWWvXrm23zSOPPGJdeeWVLY7dfvvtVn5+voszM4+dWr333nuWJOvf//53p8zJZEePHrUkWVu3bj1nm9tuu82aNGlSi2PZ2dnWfffd5/b0jGKnVitXrrR69uzZeZMy2IUXXmj9/ve/b/Mca6q19urV3dfVqVOnrMsuu8zy+/3WjTfeaD300EPnbButtdWt7qA4VVlZqXHjxrU4lp+fr8rKyijNyHzDhw9XRkaG8vLy9OGHH0Z7OlFRV1cnSUpNTT1nG9bWt+zUSpLq6+vVv39/ZWVldfi/4q7ozJkzWrNmjRoaGs75dSCsqf+yUy+pe6+ruXPnatKkSa3WTFuitbZi4tuMo6WmpqbVJ9v27dtXgUBA//nPf3TBBRdEaWbmycjI0PLlyzVq1CgFg0H9/ve/V25urrZv364RI0ZEe3qdpqmpSfPnz9ePfvQjXXXVVedsd6611R1es9PMbq0GDx6sFStWaOjQoaqrq9PTTz+t6667Tvv379fFF1/ciTPufHv37lVOTo6+/vprff/739fatWv1gx/8oM22rCln9erO62rNmjXavXu3duzYYat9tNYWAQURMXjwYA0ePDi8f9111+ngwYN65pln9Oc//zmKM+tcc+fO1b59+/TBBx9EeyrGs1urnJycFv8Lvu6663TFFVfohRde0BNPPOH2NKNq8ODBqqqqUl1dnf76179q5syZ2rp16zn/6HZ3TurVXdfVl19+qYceekh+v9/4FwUTUNqRnp6u2traFsdqa2uVkpLC3RMbRo8e3a3+UM+bN0/r169XRUVFh/8DO9faSk9Pd3OKxnBSq7N5vV5dc801qq6udml25khISNCll14qSRo5cqR27NihX//613rhhRdate3ua0pyVq+zdZd1tWvXLh09erTFne0zZ86ooqJCv/nNbxQMBtWjR48Wj4nW2uI1KO3IycnRpk2bWhzz+/3tPqeJ/6qqqlJGRka0p+E6y7I0b948rV27Vps3b9bAgQM7fEx3XVvnU6uznTlzRnv37u0Wa+tsTU1NCgaDbZ7rrmuqPe3V62zdZV2NHTtWe/fuVVVVVXgbNWqUZsyYoaqqqlbhRIri2nL1JbiGOXXqlPXxxx9bH3/8sSXJWrZsmfXxxx9bn3/+uWVZlrVgwQLrrrvuCrf/xz/+YSUlJVkPP/yw9cknn1hlZWVWjx49rA0bNkTrEjqN01o988wz1rp166xPP/3U2rt3r/XQQw9ZcXFx1saNG6N1CZ3mgQcesHr27Glt2bLFOnLkSHhrbGwMt7nrrrusBQsWhPc//PBDKz4+3nr66aetTz75xFq8eLHl9XqtvXv3RuMSOs351KqkpMR65513rIMHD1q7du2ypk2bZiUmJlr79++PxiV0mgULFlhbt261Dh06ZO3Zs8dasGCB5fF4rHfffdeyLNbU2ZzWq7uuq7ac/S4eU9ZWtwoozW+FPXubOXOmZVmWNXPmTOvGG29s9Zjhw4dbCQkJ1iWXXGKtXLmy0+cdDU5r9eSTT1qDBg2yEhMTrdTUVCs3N9favHlzdCbfydqqk6QWa+XGG28M167ZK6+8Yl1++eVWQkKCdeWVV1pvvvlm5048Cs6nVvPnz7f69etnJSQkWH379rUmTpxo7d69u/Mn38nuvfdeq3///lZCQoJ10UUXWWPHjg3/sbUs1tTZnNaru66rtpwdUExZWx7Lsix379EAAAA4w2tQAACAcQgoAADAOAQUAABgHAIKAAAwDgEFAAAYh4ACAACMQ0ABAADGIaAAAADjEFAAAIBxCCgAAMA4BBQAAGAcAgoAADDO/wMq5ShGrqTIwgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "emp_address_counts.hist()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4eb60d62",
+   "metadata": {},
+   "source": [
+    "# Check whether all addresses have a unique zip code\n",
+    "\n",
+    "## Not quite... there's one address with 2 zips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "9a37f039",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "address\n",
+       " 100th ave sw  arcadia, fl                1\n",
+       " 109th ave sw  unincorporated, fl         1\n",
+       " 10th street  unincorporated, fl          1\n",
+       " 11th ave ne  cape coral, fl              1\n",
+       " 12th ave  ormond beach, fl               1\n",
+       "                                         ..\n",
+       "w3947 stingle rd  jacksonville, fl        1\n",
+       "w654 greiner rd  titusville, fl           1\n",
+       "w6674 gn willow ct  unincorporated, fl    1\n",
+       "w7426 state highway 33  dunnellon, fl     1\n",
+       "w8581 county rd e  wesley chapel, fl      1\n",
+       "Name: zipcode, Length: 20449, dtype: int64"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zips_per_address = df_state_table.groupby('address')['zipcode'].nunique()\n",
+    "zips_per_address"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "5ee306f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1    20448\n",
+       "2        1\n",
+       "Name: zipcode, dtype: int64"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zips_per_address.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "4dacb2f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "address\n",
+       " main street  unincorporated, fl    2\n",
+       "Name: zipcode, dtype: int64"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zips_per_address.loc[zips_per_address == 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "f946b0b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tracked</th>\n",
+       "      <th>middle_name</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>relation_to_household_head</th>\n",
+       "      <th>race_ethnicity</th>\n",
+       "      <th>housing_type</th>\n",
+       "      <th>exit_time</th>\n",
+       "      <th>last_name</th>\n",
+       "      <th>state</th>\n",
+       "      <th>ssn</th>\n",
+       "      <th>...</th>\n",
+       "      <th>years_of_life_lost</th>\n",
+       "      <th>cause_of_death</th>\n",
+       "      <th>zipcode</th>\n",
+       "      <th>address</th>\n",
+       "      <th>parent_id</th>\n",
+       "      <th>last_birth_time</th>\n",
+       "      <th>employer_id</th>\n",
+       "      <th>employer_name</th>\n",
+       "      <th>employer_zipcode</th>\n",
+       "      <th>employer_address</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>13932</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Brandon</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Gonzalez</td>\n",
+       "      <td>12</td>\n",
+       "      <td>056-48-7134</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>33411</td>\n",
+       "      <td>main street  unincorporated, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>unemployed</td>\n",
+       "      <td>NA</td>\n",
+       "      <td>NA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13933</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Jana</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Opp-sex spouse</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Richards</td>\n",
+       "      <td>12</td>\n",
+       "      <td>225-28-2266</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>33411</td>\n",
+       "      <td>main street  unincorporated, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>2019-03-04 18:00:00</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>unemployed</td>\n",
+       "      <td>NA</td>\n",
+       "      <td>NA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47375</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Michael</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Garcia</td>\n",
+       "      <td>12</td>\n",
+       "      <td>326-69-8037</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>32818</td>\n",
+       "      <td>main street  unincorporated, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>93</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>33324</td>\n",
+       "      <td>6450 n hwy 97  plantation, fl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47376</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Mercedes</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Opp-sex spouse</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Garcia</td>\n",
+       "      <td>12</td>\n",
+       "      <td>567-50-4363</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>32818</td>\n",
+       "      <td>main street  unincorporated, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>2019-03-04 18:00:00</td>\n",
+       "      <td>64</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>32244</td>\n",
+       "      <td>35 katie court  jacksonville, fl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47377</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Mikel</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Biological child</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Rowland</td>\n",
+       "      <td>12</td>\n",
+       "      <td>729-49-1167</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>32818</td>\n",
+       "      <td>main street  unincorporated, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>48</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>32763</td>\n",
+       "      <td>5266 shady rd  orange city, fl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47378</th>\n",
+       "      <td>True</td>\n",
+       "      <td>Irene</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Parent-in-law</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>Ponce</td>\n",
+       "      <td>12</td>\n",
+       "      <td>387-77-8308</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>not_dead</td>\n",
+       "      <td>32818</td>\n",
+       "      <td>main street  unincorporated, fl</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>2019-03-04 18:00:00</td>\n",
+       "      <td>191</td>\n",
+       "      <td>not implemented</td>\n",
+       "      <td>33139</td>\n",
+       "      <td>9915 w hope cir  miami beach, fl</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>6 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       tracked middle_name     sex relation_to_household_head race_ethnicity  \\\n",
+       "13932     True     Brandon    Male           Reference person         Latino   \n",
+       "13933     True        Jana  Female             Opp-sex spouse          White   \n",
+       "47375     True     Michael    Male           Reference person         Latino   \n",
+       "47376     True    Mercedes  Female             Opp-sex spouse         Latino   \n",
+       "47377     True       Mikel    Male           Biological child         Latino   \n",
+       "47378     True       Irene  Female              Parent-in-law         Latino   \n",
+       "\n",
+       "      housing_type exit_time last_name  state          ssn  ...  \\\n",
+       "13932     Standard       NaT  Gonzalez     12  056-48-7134  ...   \n",
+       "13933     Standard       NaT  Richards     12  225-28-2266  ...   \n",
+       "47375     Standard       NaT    Garcia     12  326-69-8037  ...   \n",
+       "47376     Standard       NaT    Garcia     12  567-50-4363  ...   \n",
+       "47377     Standard       NaT   Rowland     12  729-49-1167  ...   \n",
+       "47378     Standard       NaT     Ponce     12  387-77-8308  ...   \n",
+       "\n",
+       "      years_of_life_lost cause_of_death zipcode  \\\n",
+       "13932                0.0       not_dead   33411   \n",
+       "13933                0.0       not_dead   33411   \n",
+       "47375                0.0       not_dead   32818   \n",
+       "47376                0.0       not_dead   32818   \n",
+       "47377                0.0       not_dead   32818   \n",
+       "47378                0.0       not_dead   32818   \n",
+       "\n",
+       "                                address  parent_id     last_birth_time  \\\n",
+       "13932   main street  unincorporated, fl         -1                 NaT   \n",
+       "13933   main street  unincorporated, fl         -1 2019-03-04 18:00:00   \n",
+       "47375   main street  unincorporated, fl         -1                 NaT   \n",
+       "47376   main street  unincorporated, fl         -1 2019-03-04 18:00:00   \n",
+       "47377   main street  unincorporated, fl         -1                 NaT   \n",
+       "47378   main street  unincorporated, fl         -1 2019-03-04 18:00:00   \n",
+       "\n",
+       "       employer_id    employer_name employer_zipcode  \\\n",
+       "13932           -1       unemployed               NA   \n",
+       "13933           -1       unemployed               NA   \n",
+       "47375           93  not implemented            33324   \n",
+       "47376           64  not implemented            32244   \n",
+       "47377           48  not implemented            32763   \n",
+       "47378          191  not implemented            33139   \n",
+       "\n",
+       "                       employer_address  \n",
+       "13932                                NA  \n",
+       "13933                                NA  \n",
+       "47375     6450 n hwy 97  plantation, fl  \n",
+       "47376  35 katie court  jacksonville, fl  \n",
+       "47377    5266 shady rd  orange city, fl  \n",
+       "47378  9915 w hope cir  miami beach, fl  \n",
+       "\n",
+       "[6 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_state_table.query(\"address == ' main street  unincorporated, fl'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "d0fe4894",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "62"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "address_counts['33411']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "20ed7dcc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "19"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "address_counts['32818']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a9e210c",
+   "metadata": {},
+   "source": [
+    "# Get dataframe with mapping of address to cleaned zipcode\n",
+    "\n",
+    "Use consecutive integers as ths index so that I can map each address ID from new census data to a number in this dataframe's index via modular arithmetic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "id": "a3916051",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>address</th>\n",
+       "      <th>clean_zipcode</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>100th ave sw  arcadia, fl</td>\n",
+       "      <td>34266</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>109th ave sw  unincorporated, fl</td>\n",
+       "      <td>33434</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>10th street  unincorporated, fl</td>\n",
+       "      <td>32807</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>11th ave ne  cape coral, fl</td>\n",
+       "      <td>33993</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>12th ave  ormond beach, fl</td>\n",
+       "      <td>32174</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20444</th>\n",
+       "      <td>w3947 stingle rd  jacksonville, fl</td>\n",
+       "      <td>32225</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20445</th>\n",
+       "      <td>w654 greiner rd  titusville, fl</td>\n",
+       "      <td>32780</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20446</th>\n",
+       "      <td>w6674 gn willow ct  unincorporated, fl</td>\n",
+       "      <td>33498</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20447</th>\n",
+       "      <td>w7426 state highway 33  dunnellon, fl</td>\n",
+       "      <td>34431</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20448</th>\n",
+       "      <td>w8581 county rd e  wesley chapel, fl</td>\n",
+       "      <td>33543</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>20449 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                      address clean_zipcode\n",
+       "0                   100th ave sw  arcadia, fl         34266\n",
+       "1            109th ave sw  unincorporated, fl         33434\n",
+       "2             10th street  unincorporated, fl         32807\n",
+       "3                 11th ave ne  cape coral, fl         33993\n",
+       "4                  12th ave  ormond beach, fl         32174\n",
+       "...                                       ...           ...\n",
+       "20444      w3947 stingle rd  jacksonville, fl         32225\n",
+       "20445         w654 greiner rd  titusville, fl         32780\n",
+       "20446  w6674 gn willow ct  unincorporated, fl         33498\n",
+       "20447   w7426 state highway 33  dunnellon, fl         34431\n",
+       "20448    w8581 county rd e  wesley chapel, fl         33543\n",
+       "\n",
+       "[20449 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "address_to_zip = (\n",
+    "    df_state_table\n",
+    "    .assign(clean_zipcode=clean_zipcode(df_state_table['zipcode']))\n",
+    "    .groupby('address', as_index=False)['clean_zipcode'].min()\n",
+    ")\n",
+    "address_to_zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "id": "021b9225",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([5])"
+      ]
+     },
+     "execution_count": 113,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "address_to_zip.clean_zipcode.str.len().unique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59c1ae13",
+   "metadata": {},
+   "source": [
+    "# Load new census data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "072d70f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 846760\r\n",
+      "-rw-r--r-- 1 albrja IHME-Simulationscience 116145705 Feb  2 11:20 decennial_census_observer.csv.bz2\r\n",
+      "-rw-r--r-- 1 albrja IHME-Simulationscience   1436741 Feb  2 11:20 household_survey_observer_acs.csv.bz2\r\n",
+      "-rw-r--r-- 1 albrja IHME-Simulationscience   7443547 Feb  2 11:20 household_survey_observer_cps.csv.bz2\r\n",
+      "-rw-r--r-- 1 albrja IHME-Simulationscience  30294533 Feb  2 11:21 social_security_observer.csv.bz2\r\n",
+      "-rw-r--r-- 1 albrja IHME-Simulationscience 696671121 Feb  2 11:27 tax_w2_observer.csv.bz2\r\n",
+      "-rw-r--r-- 1 albrja IHME-Simulationscience  15056759 Feb  2 11:20 wic_observer.csv.bz2\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls -l $new_data_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "5d66ace5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 29.6 s, sys: 1.09 s, total: 30.6 s\n",
+      "Wall time: 30.8 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>simulant_id</th>\n",
+       "      <th>last_name_id</th>\n",
+       "      <th>age</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>race_ethnicity</th>\n",
+       "      <th>date_of_birth</th>\n",
+       "      <th>address_id</th>\n",
+       "      <th>guardian_1</th>\n",
+       "      <th>guardian_2</th>\n",
+       "      <th>guardian_1_address_id</th>\n",
+       "      <th>guardian_2_address_id</th>\n",
+       "      <th>relation_to_household_head</th>\n",
+       "      <th>census_year</th>\n",
+       "      <th>housing_type</th>\n",
+       "      <th>random_seed</th>\n",
+       "      <th>year_of_birth</th>\n",
+       "      <th>first_name</th>\n",
+       "      <th>middle_initial</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>3254_0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>67.376229</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>1952-11-15</td>\n",
+       "      <td>6</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2020</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3254</td>\n",
+       "      <td>1952</td>\n",
+       "      <td>Deanna</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3254_1</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>37.501003</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>1982-10-01</td>\n",
+       "      <td>6</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Biological child</td>\n",
+       "      <td>2020</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3254</td>\n",
+       "      <td>1982</td>\n",
+       "      <td>Clifton</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3254_2</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>31.157344</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>1989-02-03</td>\n",
+       "      <td>6</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Biological child</td>\n",
+       "      <td>2020</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3254</td>\n",
+       "      <td>1989</td>\n",
+       "      <td>Christopher</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3254_3</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>37.944355</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>1982-04-22</td>\n",
+       "      <td>7</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2020</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3254</td>\n",
+       "      <td>1982</td>\n",
+       "      <td>Travis</td>\n",
+       "      <td>J</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>3254_4</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>60.986418</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>White</td>\n",
+       "      <td>1959-04-07</td>\n",
+       "      <td>8</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2020</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3254</td>\n",
+       "      <td>1959</td>\n",
+       "      <td>Davis</td>\n",
+       "      <td>T</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943280</th>\n",
+       "      <td>3541_278165</td>\n",
+       "      <td>44253.0</td>\n",
+       "      <td>0.055643</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>2030-03-28</td>\n",
+       "      <td>150569</td>\n",
+       "      <td>44253</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>150569.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Biological child</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3541</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Mila</td>\n",
+       "      <td>C</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943281</th>\n",
+       "      <td>3541_278166</td>\n",
+       "      <td>50096.0</td>\n",
+       "      <td>0.039506</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>2030-04-03</td>\n",
+       "      <td>3</td>\n",
+       "      <td>50097</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Noninstitutionalized GQ pop</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>College</td>\n",
+       "      <td>3541</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Aicha</td>\n",
+       "      <td>L</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943282</th>\n",
+       "      <td>3541_278167</td>\n",
+       "      <td>113377.0</td>\n",
+       "      <td>0.052213</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>2030-03-29</td>\n",
+       "      <td>96003</td>\n",
+       "      <td>113380</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>96003.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Biological child</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3541</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Amila</td>\n",
+       "      <td>E</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943283</th>\n",
+       "      <td>3541_278168</td>\n",
+       "      <td>140942.0</td>\n",
+       "      <td>0.016033</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>2030-04-12</td>\n",
+       "      <td>179963</td>\n",
+       "      <td>140944</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>179963.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Grandchild</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3541</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Tallulah</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943284</th>\n",
+       "      <td>3541_278169</td>\n",
+       "      <td>202912.0</td>\n",
+       "      <td>0.036503</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>2030-04-04</td>\n",
+       "      <td>77605</td>\n",
+       "      <td>202912</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>77605.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Other nonrelative</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>3541</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Braden</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>4943285 rows × 18 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         simulant_id  last_name_id        age     sex race_ethnicity  \\\n",
+       "0             3254_0           0.0  67.376229  Female          Black   \n",
+       "1             3254_1           0.0  37.501003    Male          Black   \n",
+       "2             3254_2           0.0  31.157344    Male          Black   \n",
+       "3             3254_3           3.0  37.944355    Male         Latino   \n",
+       "4             3254_4           4.0  60.986418    Male          White   \n",
+       "...              ...           ...        ...     ...            ...   \n",
+       "4943280  3541_278165       44253.0   0.055643  Female         Latino   \n",
+       "4943281  3541_278166       50096.0   0.039506  Female          Black   \n",
+       "4943282  3541_278167      113377.0   0.052213  Female          Black   \n",
+       "4943283  3541_278168      140942.0   0.016033  Female         Latino   \n",
+       "4943284  3541_278169      202912.0   0.036503    Male          Black   \n",
+       "\n",
+       "        date_of_birth  address_id  guardian_1  guardian_2  \\\n",
+       "0          1952-11-15           6          -1          -1   \n",
+       "1          1982-10-01           6          -1          -1   \n",
+       "2          1989-02-03           6          -1          -1   \n",
+       "3          1982-04-22           7          -1          -1   \n",
+       "4          1959-04-07           8          -1          -1   \n",
+       "...               ...         ...         ...         ...   \n",
+       "4943280    2030-03-28      150569       44253          -1   \n",
+       "4943281    2030-04-03           3       50097          -1   \n",
+       "4943282    2030-03-29       96003      113380          -1   \n",
+       "4943283    2030-04-12      179963      140944          -1   \n",
+       "4943284    2030-04-04       77605      202912          -1   \n",
+       "\n",
+       "         guardian_1_address_id  guardian_2_address_id  \\\n",
+       "0                          NaN                    NaN   \n",
+       "1                          NaN                    NaN   \n",
+       "2                          NaN                    NaN   \n",
+       "3                          NaN                    NaN   \n",
+       "4                          NaN                    NaN   \n",
+       "...                        ...                    ...   \n",
+       "4943280               150569.0                    NaN   \n",
+       "4943281                    3.0                    NaN   \n",
+       "4943282                96003.0                    NaN   \n",
+       "4943283               179963.0                    NaN   \n",
+       "4943284                77605.0                    NaN   \n",
+       "\n",
+       "          relation_to_household_head  census_year housing_type  random_seed  \\\n",
+       "0                   Reference person         2020     Standard         3254   \n",
+       "1                   Biological child         2020     Standard         3254   \n",
+       "2                   Biological child         2020     Standard         3254   \n",
+       "3                   Reference person         2020     Standard         3254   \n",
+       "4                   Reference person         2020     Standard         3254   \n",
+       "...                              ...          ...          ...          ...   \n",
+       "4943280             Biological child         2030     Standard         3541   \n",
+       "4943281  Noninstitutionalized GQ pop         2030      College         3541   \n",
+       "4943282             Biological child         2030     Standard         3541   \n",
+       "4943283                   Grandchild         2030     Standard         3541   \n",
+       "4943284            Other nonrelative         2030     Standard         3541   \n",
+       "\n",
+       "         year_of_birth   first_name middle_initial  \n",
+       "0                 1952       Deanna              S  \n",
+       "1                 1982      Clifton              S  \n",
+       "2                 1989  Christopher              S  \n",
+       "3                 1982       Travis              J  \n",
+       "4                 1959        Davis              T  \n",
+       "...                ...          ...            ...  \n",
+       "4943280           2030         Mila              C  \n",
+       "4943281           2030        Aicha              L  \n",
+       "4943282           2030        Amila              E  \n",
+       "4943283           2030     Tallulah              S  \n",
+       "4943284           2030       Braden              M  \n",
+       "\n",
+       "[4943285 rows x 18 columns]"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "df_census = pd.read_csv(f'{new_data_dir}/decennial_census_observer.csv.bz2')\n",
+    "df_census"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "id": "703ec5b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "simulant_id                    object\n",
+       "last_name_id                  float64\n",
+       "age                           float64\n",
+       "sex                            object\n",
+       "race_ethnicity                 object\n",
+       "date_of_birth                  object\n",
+       "address_id                      int64\n",
+       "guardian_1                      int64\n",
+       "guardian_2                      int64\n",
+       "guardian_1_address_id         float64\n",
+       "guardian_2_address_id         float64\n",
+       "relation_to_household_head     object\n",
+       "census_year                     int64\n",
+       "housing_type                   object\n",
+       "random_seed                     int64\n",
+       "year_of_birth                   int64\n",
+       "first_name                     object\n",
+       "middle_initial                 object\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_census.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "id": "25115ff0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index([], dtype='object')"
+      ]
+     },
+     "execution_count": 124,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_census.filter(like='zip').columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5755ef5",
+   "metadata": {},
+   "source": [
+    "# Figure out how to map each address IDs from new census data to an address (hence zipcode) in the original data\n",
+    "\n",
+    "The idea is to just mod the address ID by the number of original addresses, then use the modded ID as the index in the `address_to_zip` map.\n",
+    "\n",
+    "Ideally, the address IDs would be consecutive integers up to the maximum ID so that we're guaranteed an approximately uniform mapping into the original addresses (hence zipcodes).\n",
+    "\n",
+    "It looks like the address IDs are not quite consecutive, but there are only 77 values missing between the minimum 0 and the maximum 189,912. We could just ignore this and probably get a good enough mapping anyway. But instead, I just took all the address IDs that were greater than or equal to the number of unique IDs (189,836), and replaced each of these with one of the 77 missing values. Conveniently, each of the 77 missing values appeared only once in the dataframe, which made this very easy to do."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "d2faee94",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    4.943285e+06\n",
+       "mean     7.023635e+04\n",
+       "std      5.381825e+04\n",
+       "min      0.000000e+00\n",
+       "25%      2.655600e+04\n",
+       "50%      6.048500e+04\n",
+       "75%      9.719400e+04\n",
+       "max      1.899120e+05\n",
+       "Name: address_id, dtype: float64"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_census.address_id.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "c8993872",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "189836"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_census.address_id.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "id": "1d3e4826",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "189913"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_census.address_id.max()+1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "c62cc4ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "77"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "189913 - 189836"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6f656c1",
+   "metadata": {},
+   "source": [
+    "## Find missing 77 ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "d107cb1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "77\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[108551,\n",
+       " 109068,\n",
+       " 121370,\n",
+       " 101921,\n",
+       " 94755,\n",
+       " 98370,\n",
+       " 100930,\n",
+       " 102479,\n",
+       " 100951,\n",
+       " 99418,\n",
+       " 105051,\n",
+       " 103005,\n",
+       " 113255,\n",
+       " 117351,\n",
+       " 112754,\n",
+       " 111762,\n",
+       " 115346,\n",
+       " 110228,\n",
+       " 133778,\n",
+       " 102039,\n",
+       " 100507,\n",
+       " 105120,\n",
+       " 124067,\n",
+       " 96935,\n",
+       " 105132,\n",
+       " 101562,\n",
+       " 117453,\n",
+       " 133341,\n",
+       " 101088,\n",
+       " 105705,\n",
+       " 104686,\n",
+       " 122620,\n",
+       " 99586,\n",
+       " 103690,\n",
+       " 106251,\n",
+       " 114956,\n",
+       " 107793,\n",
+       " 108311,\n",
+       " 115993,\n",
+       " 114459,\n",
+       " 112418,\n",
+       " 111397,\n",
+       " 99633,\n",
+       " 107825,\n",
+       " 99638,\n",
+       " 119126,\n",
+       " 101227,\n",
+       " 100210,\n",
+       " 99703,\n",
+       " 94072,\n",
+       " 111479,\n",
+       " 98171,\n",
+       " 119684,\n",
+       " 119187,\n",
+       " 103320,\n",
+       " 106398,\n",
+       " 106917,\n",
+       " 115622,\n",
+       " 100263,\n",
+       " 103338,\n",
+       " 101296,\n",
+       " 132027,\n",
+       " 103358,\n",
+       " 106430,\n",
+       " 103872,\n",
+       " 97731,\n",
+       " 133064,\n",
+       " 112075,\n",
+       " 96208,\n",
+       " 119249,\n",
+       " 102355,\n",
+       " 120792,\n",
+       " 114650,\n",
+       " 114143,\n",
+       " 96228,\n",
+       " 98290,\n",
+       " 99835]"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "missing_ids = list(set(range(189913)).difference(df_census.address_id))\n",
+    "print(len(missing_ids))\n",
+    "missing_ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddf4e4fb",
+   "metadata": {},
+   "source": [
+    "## Find address IDs greater than or equal to the number of unique IDs\n",
+    "\n",
+    "Conveniently, each of these only shows up once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "b70f28f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>simulant_id</th>\n",
+       "      <th>last_name_id</th>\n",
+       "      <th>age</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>race_ethnicity</th>\n",
+       "      <th>date_of_birth</th>\n",
+       "      <th>address_id</th>\n",
+       "      <th>guardian_1</th>\n",
+       "      <th>guardian_2</th>\n",
+       "      <th>guardian_1_address_id</th>\n",
+       "      <th>guardian_2_address_id</th>\n",
+       "      <th>relation_to_household_head</th>\n",
+       "      <th>census_year</th>\n",
+       "      <th>housing_type</th>\n",
+       "      <th>random_seed</th>\n",
+       "      <th>year_of_birth</th>\n",
+       "      <th>first_name</th>\n",
+       "      <th>middle_initial</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1896572</th>\n",
+       "      <td>2787_188277</td>\n",
+       "      <td>188277.0</td>\n",
+       "      <td>35.636775</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>White</td>\n",
+       "      <td>1994-07-31</td>\n",
+       "      <td>189836</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>1994</td>\n",
+       "      <td>Henry</td>\n",
+       "      <td>J</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1896937</th>\n",
+       "      <td>2787_188688</td>\n",
+       "      <td>188687.0</td>\n",
+       "      <td>98.313706</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>White</td>\n",
+       "      <td>1931-11-26</td>\n",
+       "      <td>189837</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>1931</td>\n",
+       "      <td>Frances</td>\n",
+       "      <td>N</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1897811</th>\n",
+       "      <td>2787_189698</td>\n",
+       "      <td>189698.0</td>\n",
+       "      <td>24.811578</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>White</td>\n",
+       "      <td>2005-05-28</td>\n",
+       "      <td>189838</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>2005</td>\n",
+       "      <td>Caroline</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1897979</th>\n",
+       "      <td>2787_189885</td>\n",
+       "      <td>189885.0</td>\n",
+       "      <td>31.322687</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>White</td>\n",
+       "      <td>1998-11-22</td>\n",
+       "      <td>189839</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>1998</td>\n",
+       "      <td>Charlie</td>\n",
+       "      <td>D</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1898507</th>\n",
+       "      <td>2787_190499</td>\n",
+       "      <td>190497.0</td>\n",
+       "      <td>35.613311</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Latino</td>\n",
+       "      <td>1994-08-08</td>\n",
+       "      <td>189840</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>1994</td>\n",
+       "      <td>Logan</td>\n",
+       "      <td>J</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1946255</th>\n",
+       "      <td>2787_245536</td>\n",
+       "      <td>245536.0</td>\n",
+       "      <td>26.515258</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>White</td>\n",
+       "      <td>2003-09-13</td>\n",
+       "      <td>189908</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>2003</td>\n",
+       "      <td>Sophie</td>\n",
+       "      <td>A</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1947110</th>\n",
+       "      <td>2787_246525</td>\n",
+       "      <td>246525.0</td>\n",
+       "      <td>67.512967</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>White</td>\n",
+       "      <td>1962-09-14</td>\n",
+       "      <td>189909</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>1962</td>\n",
+       "      <td>Wayne</td>\n",
+       "      <td>G</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1947123</th>\n",
+       "      <td>2787_246540</td>\n",
+       "      <td>246540.0</td>\n",
+       "      <td>30.324946</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>1999-11-22</td>\n",
+       "      <td>189910</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>1999</td>\n",
+       "      <td>Hunter</td>\n",
+       "      <td>J</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1948532</th>\n",
+       "      <td>2787_248368</td>\n",
+       "      <td>248368.0</td>\n",
+       "      <td>28.082727</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>White</td>\n",
+       "      <td>2002-02-18</td>\n",
+       "      <td>189911</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>2002</td>\n",
+       "      <td>Kevin</td>\n",
+       "      <td>E</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1948986</th>\n",
+       "      <td>2787_248950</td>\n",
+       "      <td>248950.0</td>\n",
+       "      <td>33.690303</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Multiracial or Other</td>\n",
+       "      <td>1996-07-11</td>\n",
+       "      <td>189912</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Reference person</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>Standard</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>1996</td>\n",
+       "      <td>Daniel</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>77 rows × 18 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         simulant_id  last_name_id        age     sex        race_ethnicity  \\\n",
+       "1896572  2787_188277      188277.0  35.636775    Male                 White   \n",
+       "1896937  2787_188688      188687.0  98.313706  Female                 White   \n",
+       "1897811  2787_189698      189698.0  24.811578  Female                 White   \n",
+       "1897979  2787_189885      189885.0  31.322687  Female                 White   \n",
+       "1898507  2787_190499      190497.0  35.613311    Male                Latino   \n",
+       "...              ...           ...        ...     ...                   ...   \n",
+       "1946255  2787_245536      245536.0  26.515258  Female                 White   \n",
+       "1947110  2787_246525      246525.0  67.512967    Male                 White   \n",
+       "1947123  2787_246540      246540.0  30.324946    Male                 Black   \n",
+       "1948532  2787_248368      248368.0  28.082727    Male                 White   \n",
+       "1948986  2787_248950      248950.0  33.690303    Male  Multiracial or Other   \n",
+       "\n",
+       "        date_of_birth  address_id  guardian_1  guardian_2  \\\n",
+       "1896572    1994-07-31      189836          -1          -1   \n",
+       "1896937    1931-11-26      189837          -1          -1   \n",
+       "1897811    2005-05-28      189838          -1          -1   \n",
+       "1897979    1998-11-22      189839          -1          -1   \n",
+       "1898507    1994-08-08      189840          -1          -1   \n",
+       "...               ...         ...         ...         ...   \n",
+       "1946255    2003-09-13      189908          -1          -1   \n",
+       "1947110    1962-09-14      189909          -1          -1   \n",
+       "1947123    1999-11-22      189910          -1          -1   \n",
+       "1948532    2002-02-18      189911          -1          -1   \n",
+       "1948986    1996-07-11      189912          -1          -1   \n",
+       "\n",
+       "         guardian_1_address_id  guardian_2_address_id  \\\n",
+       "1896572                    NaN                    NaN   \n",
+       "1896937                    NaN                    NaN   \n",
+       "1897811                    NaN                    NaN   \n",
+       "1897979                    NaN                    NaN   \n",
+       "1898507                    NaN                    NaN   \n",
+       "...                        ...                    ...   \n",
+       "1946255                    NaN                    NaN   \n",
+       "1947110                    NaN                    NaN   \n",
+       "1947123                    NaN                    NaN   \n",
+       "1948532                    NaN                    NaN   \n",
+       "1948986                    NaN                    NaN   \n",
+       "\n",
+       "        relation_to_household_head  census_year housing_type  random_seed  \\\n",
+       "1896572           Reference person         2030     Standard         2787   \n",
+       "1896937           Reference person         2030     Standard         2787   \n",
+       "1897811           Reference person         2030     Standard         2787   \n",
+       "1897979           Reference person         2030     Standard         2787   \n",
+       "1898507           Reference person         2030     Standard         2787   \n",
+       "...                            ...          ...          ...          ...   \n",
+       "1946255           Reference person         2030     Standard         2787   \n",
+       "1947110           Reference person         2030     Standard         2787   \n",
+       "1947123           Reference person         2030     Standard         2787   \n",
+       "1948532           Reference person         2030     Standard         2787   \n",
+       "1948986           Reference person         2030     Standard         2787   \n",
+       "\n",
+       "         year_of_birth first_name middle_initial  \n",
+       "1896572           1994      Henry              J  \n",
+       "1896937           1931    Frances              N  \n",
+       "1897811           2005   Caroline              M  \n",
+       "1897979           1998    Charlie              D  \n",
+       "1898507           1994      Logan              J  \n",
+       "...                ...        ...            ...  \n",
+       "1946255           2003     Sophie              A  \n",
+       "1947110           1962      Wayne              G  \n",
+       "1947123           1999     Hunter              J  \n",
+       "1948532           2002      Kevin              E  \n",
+       "1948986           1996     Daniel              M  \n",
+       "\n",
+       "[77 rows x 18 columns]"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_census.query(\"address_id >= 189836\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1170bbab",
+   "metadata": {},
+   "source": [
+    "## Make the address IDs consecutive by replacing each of the 77 above IDs with one of the missing IDs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "facba84b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0               6\n",
+       "1               6\n",
+       "2               6\n",
+       "3               7\n",
+       "4               8\n",
+       "            ...  \n",
+       "4943280    150569\n",
+       "4943281         3\n",
+       "4943282     96003\n",
+       "4943283    179963\n",
+       "4943284     77605\n",
+       "Name: address_id, Length: 4943285, dtype: int64"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_address_ids = df_census.address_id.copy()\n",
+    "new_address_ids.loc[new_address_ids >= 189836] = missing_ids\n",
+    "new_address_ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "4372af3b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "set(new_address_ids).difference(df_census.address_id) == set(missing_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "789fe871",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "set()"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "set(range(189836)).difference(new_address_ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e14f63a0",
+   "metadata": {},
+   "source": [
+    "## Create a mapping from rows in the new census data to zipcodes from the original data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 116,
+   "id": "39b3d0a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>address_id</th>\n",
+       "      <th>consecutive_address_id</th>\n",
+       "      <th>index_of_orig_address</th>\n",
+       "      <th>orig_address</th>\n",
+       "      <th>zipcode</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>6</td>\n",
+       "      <td>6</td>\n",
+       "      <td>6</td>\n",
+       "      <td>13th ave w  unincorporated, fl</td>\n",
+       "      <td>33462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>6</td>\n",
+       "      <td>6</td>\n",
+       "      <td>6</td>\n",
+       "      <td>13th ave w  unincorporated, fl</td>\n",
+       "      <td>33462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>6</td>\n",
+       "      <td>6</td>\n",
+       "      <td>6</td>\n",
+       "      <td>13th ave w  unincorporated, fl</td>\n",
+       "      <td>33462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>7</td>\n",
+       "      <td>7</td>\n",
+       "      <td>7</td>\n",
+       "      <td>13th avenue southwest  lakeland, fl</td>\n",
+       "      <td>33811</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>8</td>\n",
+       "      <td>8</td>\n",
+       "      <td>8</td>\n",
+       "      <td>14th street  fern prk, fl</td>\n",
+       "      <td>32730</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943280</th>\n",
+       "      <td>150569</td>\n",
+       "      <td>150569</td>\n",
+       "      <td>7426</td>\n",
+       "      <td>2025 e roosevelt ct  kissimmee, fl</td>\n",
+       "      <td>34741</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943281</th>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>11th ave ne  cape coral, fl</td>\n",
+       "      <td>33993</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943282</th>\n",
+       "      <td>96003</td>\n",
+       "      <td>96003</td>\n",
+       "      <td>14207</td>\n",
+       "      <td>4647 coleherne road  winter park, fl</td>\n",
+       "      <td>32792</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943283</th>\n",
+       "      <td>179963</td>\n",
+       "      <td>179963</td>\n",
+       "      <td>16371</td>\n",
+       "      <td>605 tce hill ln  englewood, fl</td>\n",
+       "      <td>34224</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943284</th>\n",
+       "      <td>77605</td>\n",
+       "      <td>77605</td>\n",
+       "      <td>16258</td>\n",
+       "      <td>6000 kirk rd  cape coral, fl</td>\n",
+       "      <td>33914</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>4943285 rows × 5 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         address_id  consecutive_address_id  index_of_orig_address  \\\n",
+       "0                 6                       6                      6   \n",
+       "1                 6                       6                      6   \n",
+       "2                 6                       6                      6   \n",
+       "3                 7                       7                      7   \n",
+       "4                 8                       8                      8   \n",
+       "...             ...                     ...                    ...   \n",
+       "4943280      150569                  150569                   7426   \n",
+       "4943281           3                       3                      3   \n",
+       "4943282       96003                   96003                  14207   \n",
+       "4943283      179963                  179963                  16371   \n",
+       "4943284       77605                   77605                  16258   \n",
+       "\n",
+       "                                 orig_address zipcode  \n",
+       "0              13th ave w  unincorporated, fl   33462  \n",
+       "1              13th ave w  unincorporated, fl   33462  \n",
+       "2              13th ave w  unincorporated, fl   33462  \n",
+       "3         13th avenue southwest  lakeland, fl   33811  \n",
+       "4                   14th street  fern prk, fl   32730  \n",
+       "...                                       ...     ...  \n",
+       "4943280    2025 e roosevelt ct  kissimmee, fl   34741  \n",
+       "4943281           11th ave ne  cape coral, fl   33993  \n",
+       "4943282  4647 coleherne road  winter park, fl   32792  \n",
+       "4943283        605 tce hill ln  englewood, fl   34224  \n",
+       "4943284          6000 kirk rd  cape coral, fl   33914  \n",
+       "\n",
+       "[4943285 rows x 5 columns]"
+      ]
+     },
+     "execution_count": 116,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "census_zips = (\n",
+    "    pd.DataFrame(\n",
+    "        {\n",
+    "            'address_id': df_census['address_id'],\n",
+    "            'consecutive_address_id': new_address_ids,\n",
+    "            'index_of_orig_address': new_address_ids % len(address_to_zip)\n",
+    "        },\n",
+    "        index=df_census.index\n",
+    "    )\n",
+    "    .join(address_to_zip, on='index_of_orig_address')\n",
+    "    .rename(columns={'address': 'orig_address', 'clean_zipcode': 'zipcode'})\n",
+    ")\n",
+    "census_zips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "id": "f40186f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "zipcode\n",
+       "32003    306\n",
+       "32008     46\n",
+       "32009     19\n",
+       "32011     95\n",
+       "32024      9\n",
+       "        ... \n",
+       "34987     63\n",
+       "34990    249\n",
+       "34994    141\n",
+       "34996    169\n",
+       "34997    260\n",
+       "Name: address_id, Length: 857, dtype: int64"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "census_addresses_per_zip = census_zips.groupby('zipcode')['address_id'].nunique()\n",
+    "census_addresses_per_zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "id": "dd1937e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9      38\n",
+       "18     18\n",
+       "19     13\n",
+       "38     12\n",
+       "46     11\n",
+       "       ..\n",
+       "277     1\n",
+       "539     1\n",
+       "262     1\n",
+       "279     1\n",
+       "59      1\n",
+       "Name: address_id, Length: 357, dtype: int64"
+      ]
+     },
+     "execution_count": 118,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "census_addresses_per_zip.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "id": "d33f7d5e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot: >"
+      ]
+     },
+     "execution_count": 119,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGdCAYAAACyzRGfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAs/0lEQVR4nO3dfXSU5YH+8WsCwyQRJpEgCZEEsi4VFHxZMDDCthUDWZYqlhytQi1Fjq41voR0UdkKBtTy0lOgugFql8b11IiyK7RYhcaoWA7hLYqKdiNu0VhDwvqSDJBmGMn9+8NfpkwSIJMM9zAz3885OXGe5577ua9JQi6fPDPjMMYYAQAAWJIQ6QUAAID4QvkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYFXvSC+gvdbWVtXV1alfv35yOByRXg4AAOgCY4yOHDmizMxMJSSc/tzGOVc+6urqlJWVFellAACAbvjkk080ePDg044558pHv379JH29eLfb3eP5/H6//vCHP2jy5MlyOp09ni+akJ3sZI8v8Zyf7JHP7vV6lZWVFfg9fjrnXPlo+1OL2+0OW/lITk6W2+2Oy29IspM9nsRzdim+85P93MnelUsmuOAUAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABW9Y70Amwb+uDvg25/tHRqhFYCAEB84swHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAqpDKx4kTJ7RgwQLl5OQoKSlJF110kR555BEZYwJjjDFauHChBg0apKSkJOXl5enAgQNhXzgAAIhOIZWPZcuWac2aNfr3f/93/elPf9KyZcu0fPlyPfHEE4Exy5cv1+OPP661a9dq165dOu+885Sfn6+WlpawLx4AAESf3qEM3rFjh6ZNm6apU79+G/qhQ4fq2Wef1e7duyV9fdZj1apVeuihhzRt2jRJ0tNPP6309HRt2rRJN998c5iXDwAAok1I5ePqq6/Wk08+qQ8++EDf+MY39Pbbb2v79u1asWKFJOngwYOqr69XXl5e4D4pKSkaO3asqqqqOi0fPp9PPp8vcNvr9UqS/H6//H5/t0KdrG2Ots+uXqbT/bGoffZ4Qnayx6N4zk/2yGcP5fgOc/IFG2fQ2tqqf/u3f9Py5cvVq1cvnThxQo899pjmz58v6eszI+PHj1ddXZ0GDRoUuN9NN90kh8Oh5557rsOcJSUlWrRoUYft5eXlSk5O7nIQAAAQOc3NzZoxY4aamprkdrtPOzakMx/PP/+8nnnmGZWXl+vSSy/Vvn37VFRUpMzMTM2aNatbi50/f76Ki4sDt71er7KysjR58uQzLr4r/H6/KioqNGnSJDmdTo0s2Rq0f39Jfo+Pca5qnz2ekJ3s8ZZdiu/8ZI989ra/XHRFSOVj3rx5evDBBwN/Phk1apQ+/vhjLVmyRLNmzVJGRoYkqaGhIejMR0NDg6644opO53S5XHK5XB22O53OsD6IbfP5Tjg6bI914X4sownZyR6P4jk/2SOXPZRjh/Rsl+bmZiUkBN+lV69eam1tlSTl5OQoIyNDlZWVgf1er1e7du2Sx+MJ5VAAACBGhXTm47rrrtNjjz2m7OxsXXrppXrrrbe0YsUK3XbbbZIkh8OhoqIiPfrooxo2bJhycnK0YMECZWZm6oYbbjgb6wcAAFEmpPLxxBNPaMGCBbrrrrt0+PBhZWZm6l/+5V+0cOHCwJj7779fx44d0x133KHGxkZNmDBBW7ZsUWJiYtgXDwAAok9I5aNfv35atWqVVq1adcoxDodDixcv1uLFi3u6NgAAEIN4bxcAAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVoVUPoYOHSqHw9Hho7CwUJLU0tKiwsJCpaWlqW/fviooKFBDQ8NZWTgAAIhOIZWPPXv26NChQ4GPiooKSdKNN94oSZo7d642b96sDRs2aNu2baqrq9P06dPDv2oAABC1eocy+IILLgi6vXTpUl100UX61re+paamJq1bt07l5eWaOHGiJKmsrEwjRozQzp07NW7cuPCtGgAARK2QysfJjh8/rt/85jcqLi6Ww+FQdXW1/H6/8vLyAmOGDx+u7OxsVVVVnbJ8+Hw++Xy+wG2v1ytJ8vv98vv93V1eQNscbZ9dvUyn+2NR++zxhOxkj0fxnJ/skc8eyvEdxhhz5mEdPf/885oxY4Zqa2uVmZmp8vJyzZ49O6hISFJubq6uueYaLVu2rNN5SkpKtGjRog7by8vLlZyc3J2lAQAAy5qbmzVjxgw1NTXJ7Xafdmy3z3ysW7dOU6ZMUWZmZnenkCTNnz9fxcXFgdter1dZWVmaPHnyGRffFX6/XxUVFZo0aZKcTqdGlmwN2r+/JL/HxzhXtc8eT8hO9njLLsV3frJHPnvbXy66olvl4+OPP9Yrr7yiF154IbAtIyNDx48fV2Njo1JTUwPbGxoalJGRccq5XC6XXC5Xh+1OpzOsD2LbfL4Tjg7bY124H8toQnayx6N4zk/2yGUP5djdep2PsrIyDRw4UFOnTg1sGz16tJxOpyorKwPbampqVFtbK4/H053DAACAGBTymY/W1laVlZVp1qxZ6t37b3dPSUnRnDlzVFxcrP79+8vtduuee+6Rx+PhmS4AACAg5PLxyiuvqLa2VrfddluHfStXrlRCQoIKCgrk8/mUn5+v1atXh2WhAAAgNoRcPiZPnqxTPUEmMTFRpaWlKi0t7fHCAABAbOK9XQAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYFXL5+PTTT/X9739faWlpSkpK0qhRo7R3797AfmOMFi5cqEGDBikpKUl5eXk6cOBAWBcNAACiV0jl48svv9T48ePldDr18ssv6/3339fPf/5znX/++YExy5cv1+OPP661a9dq165dOu+885Sfn6+WlpawLx4AAESf3qEMXrZsmbKyslRWVhbYlpOTE/hvY4xWrVqlhx56SNOmTZMkPf3000pPT9emTZt08803h2nZAAAgWoVUPn73u98pPz9fN954o7Zt26YLL7xQd911l26//XZJ0sGDB1VfX6+8vLzAfVJSUjR27FhVVVV1Wj58Pp98Pl/gttfrlST5/X75/f5uhTpZ2xxtn129TKf7Y1H77PGE7GSPR/Gcn+yRzx7K8R3GGHPmYV9LTEyUJBUXF+vGG2/Unj17dN9992nt2rWaNWuWduzYofHjx6uurk6DBg0K3O+mm26Sw+HQc88912HOkpISLVq0qMP28vJyJScndzkIAACInObmZs2YMUNNTU1yu92nHRtS+ejTp4/GjBmjHTt2BLbde++92rNnj6qqqrpVPjo785GVlaXPPvvsjIvvCr/fr4qKCk2aNElOp1MjS7YG7d9fkt/jY5yr2mePJ2Qne7xll+I7P9kjn93r9WrAgAFdKh8h/dll0KBBuuSSS4K2jRgxQv/93/8tScrIyJAkNTQ0BJWPhoYGXXHFFZ3O6XK55HK5Omx3Op1hfRDb5vOdcHTYHuvC/VhGE7KTPR7Fc36yRy57KMcO6dku48ePV01NTdC2Dz74QEOGDJH09cWnGRkZqqysDOz3er3atWuXPB5PKIcCAAAxKqQzH3PnztXVV1+tn/70p7rpppu0e/duPfnkk3ryySclSQ6HQ0VFRXr00Uc1bNgw5eTkaMGCBcrMzNQNN9xwNtYPAACiTEjl46qrrtLGjRs1f/58LV68WDk5OVq1apVmzpwZGHP//ffr2LFjuuOOO9TY2KgJEyZoy5YtgYtVAQBAfAupfEjSd77zHX3nO9855X6Hw6HFixdr8eLFPVoYAACITby3CwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrQiofJSUlcjgcQR/Dhw8P7G9paVFhYaHS0tLUt29fFRQUqKGhIeyLBgAA0SvkMx+XXnqpDh06FPjYvn17YN/cuXO1efNmbdiwQdu2bVNdXZ2mT58e1gUDAIDo1jvkO/TurYyMjA7bm5qatG7dOpWXl2vixImSpLKyMo0YMUI7d+7UuHHjer5aAAAQ9UIuHwcOHFBmZqYSExPl8Xi0ZMkSZWdnq7q6Wn6/X3l5eYGxw4cPV3Z2tqqqqk5ZPnw+n3w+X+C21+uVJPn9fvn9/lCX10HbHG2fXb1Mp/tjUfvs8YTsZI9H8Zyf7JHPHsrxHcYYc+ZhX3v55Zd19OhRXXzxxTp06JAWLVqkTz/9VPv379fmzZs1e/bsoCIhSbm5ubrmmmu0bNmyTucsKSnRokWLOmwvLy9XcnJyl4MAAIDIaW5u1owZM9TU1CS3233asSGVj/YaGxs1ZMgQrVixQklJSd0qH52d+cjKytJnn312xsV3hd/vV0VFhSZNmiSn06mRJVuD9u8vye/xMc5V7bPHE7KTPd6yS/Gdn+yRz+71ejVgwIAulY+Q/+xystTUVH3jG9/Qhx9+qEmTJun48eNqbGxUampqYExDQ0On14i0cblccrlcHbY7nc6wPoht8/lOODpsj3XhfiyjCdnJHo/iOT/ZI5c9lGP36HU+jh49qv/93//VoEGDNHr0aDmdTlVWVgb219TUqLa2Vh6PpyeHAQAAMSSkMx//+q//quuuu05DhgxRXV2dHn74YfXq1Uu33HKLUlJSNGfOHBUXF6t///5yu92655575PF4eKYLAAAICKl8/OUvf9Ett9yizz//XBdccIEmTJignTt36oILLpAkrVy5UgkJCSooKJDP51N+fr5Wr159VhYOAACiU0jlY/369afdn5iYqNLSUpWWlvZoUQAAIHbx3i4AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsIryAQAArKJ8AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKyifAAAAKsoHwAAwCrKBwAAsKpH5WPp0qVyOBwqKioKbGtpaVFhYaHS0tLUt29fFRQUqKGhoafrBAAAMaLb5WPPnj365S9/qcsuuyxo+9y5c7V582Zt2LBB27ZtU11dnaZPn97jhQIAgNjQrfJx9OhRzZw5U7/61a90/vnnB7Y3NTVp3bp1WrFihSZOnKjRo0errKxMO3bs0M6dO8O2aAAAEL26VT4KCws1depU5eXlBW2vrq6W3+8P2j58+HBlZ2erqqqqZysFAAAxoXeod1i/fr3efPNN7dmzp8O++vp69enTR6mpqUHb09PTVV9f3+l8Pp9PPp8vcNvr9UqS/H6//H5/qMvroG2Ots+uXqbT/bGoffZ4Qnayx6N4zk/2yGcP5fghlY9PPvlE9913nyoqKpSYmBjywjqzZMkSLVq0qMP2P/zhD0pOTg7LMSSpoqJCkrQ8N3j7Sy+9FLZjnKvasscjsseneM4uxXd+skdOc3Nzl8c6jDHmzMO+tmnTJn33u99Vr169AttOnDghh8OhhIQEbd26VXl5efryyy+Dzn4MGTJERUVFmjt3boc5OzvzkZWVpc8++0xut7vLQU7F7/eroqJCkyZNktPp1MiSrUH795fk9/gYkjrM2925wzWP1DF7PCE72eMtuxTf+cke+exer1cDBgxQU1PTGX9/h3Tm49prr9W7774btG327NkaPny4HnjgAWVlZcnpdKqyslIFBQWSpJqaGtXW1srj8XQ6p8vlksvl6rDd6XSG9UFsm893wtFhezi0n7e7c4drnvb3j7cfxjZkJ3s8iuf8ZI9c9lCOHVL56Nevn0aOHBm07bzzzlNaWlpg+5w5c1RcXKz+/fvL7Xbrnnvukcfj0bhx40I5FAAAiFEhX3B6JitXrlRCQoIKCgrk8/mUn5+v1atXh/swAAAgSvW4fLz++utBtxMTE1VaWqrS0tKeTg0AAGIQ7+0CAACsonwAAACrKB8xrO1puyNLtmrog7+P8GoAAPga5QMAAFhF+QAAAFZRPgAAgFVhf52PaNPZtRAfLZ0agZUAABAfOPMBAACsonwAAACrKB8AAMCquL/mozNdeU0MrgsBAKB7OPMBAACsonwAAACrKB8AAMAqygcAALCKC04t4gXNAADgzAcAALCM8gEAAKyifAAAAKu45iMKtL9WJJzXiZzNuQEA6AxnPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFgVUvlYs2aNLrvsMrndbrndbnk8Hr388suB/S0tLSosLFRaWpr69u2rgoICNTQ0hH3RAAAgeoVUPgYPHqylS5equrpae/fu1cSJEzVt2jS99957kqS5c+dq8+bN2rBhg7Zt26a6ujpNnz79rCwcAABEp5De1fa6664Luv3YY49pzZo12rlzpwYPHqx169apvLxcEydOlCSVlZVpxIgR2rlzp8aNGxe+VQMAgKjV7Ws+Tpw4ofXr1+vYsWPyeDyqrq6W3+9XXl5eYMzw4cOVnZ2tqqqqsCwWAABEv5DOfEjSu+++K4/Ho5aWFvXt21cbN27UJZdcon379qlPnz5KTU0NGp+enq76+vpTzufz+eTz+QK3vV6vJMnv98vv94e6vA7a5mj77OplejznyfO16WzecI05031OxZVggj53dr/2xwvHY34uaP91jydkj8/sUnznJ3vks4dyfIcxJqTfxsePH1dtba2ampr0X//1X/qP//gPbdu2Tfv27dPs2bODioQk5ebm6pprrtGyZcs6na+kpESLFi3qsL28vFzJycmhLA0AAERIc3OzZsyYoaamJrnd7tOODbl8tJeXl6eLLrpI3/ve93Tttdfqyy+/DDr7MWTIEBUVFWnu3Lmd3r+zMx9ZWVn67LPPzrj4rvD7/aqoqNCkSZPkdDo1smRrj+eUpP0l+UG3O5s3XGO6sx5JGr14ix4Z06oFexPka3V0Oqb98TobE43af93jCdnjM7sU3/nJHvnsXq9XAwYM6FL5CPnPLu21trbK5/Np9OjRcjqdqqysVEFBgSSppqZGtbW18ng8p7y/y+WSy+XqsN3pdIb1QWybz3fCEbb5TtbZvOEa0531SJKv1RH47Dvh6HxMu+PF2g9tuL+PognZ4zO7FN/5yR657KEcO6TyMX/+fE2ZMkXZ2dk6cuSIysvL9frrr2vr1q1KSUnRnDlzVFxcrP79+8vtduuee+6Rx+PhmS4AACAgpPJx+PBh/eAHP9ChQ4eUkpKiyy67TFu3btWkSZMkSStXrlRCQoIKCgrk8/mUn5+v1atXn5WFAwCA6BRS+Vi3bt1p9ycmJqq0tFSlpaU9WhQAAIhdvLcLAACwivIBAACsonwAAACrKB8AAMAqygcAALCK8gEAAKzq8Suc4tSGPvj7SC8hyLm2HgBAfOLMBwAAsIryAQAArKJ8AAAAq7jmI0Z0dj2Hq1cEFgIAwBlw5gMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAVbyyHsGj/xnYfLZ0aoZUAAM51nPkAAABWUT4AAIBVlA8AAGAV13wgSPtrNySu3wAAhBdnPgAAgFWUDwAAYBXlAwAAWBVS+ViyZImuuuoq9evXTwMHDtQNN9ygmpqaoDEtLS0qLCxUWlqa+vbtq4KCAjU0NIR10QAAIHqFVD62bdumwsJC7dy5UxUVFfL7/Zo8ebKOHTsWGDN37lxt3rxZGzZs0LZt21RXV6fp06eHfeEAACA6hfRsly1btgTdfuqppzRw4EBVV1frm9/8ppqamrRu3TqVl5dr4sSJkqSysjKNGDFCO3fu1Lhx48K3cgAAEJV69FTbpqYmSVL//v0lSdXV1fL7/crLywuMGT58uLKzs1VVVdVp+fD5fPL5fIHbXq9XkuT3++X3+3uyvMA8J3929TI9nvPk+dp0d95wzdMZV4IJ+txdXfk6tF93OL52PdH+6x5PyB6f2aX4zk/2yGcP5fgOY0y3fjO1trbq+uuvV2Njo7Zv3y5JKi8v1+zZs4PKhCTl5ubqmmuu0bJlyzrMU1JSokWLFnXYXl5eruTk5O4sDQAAWNbc3KwZM2aoqalJbrf7tGO7feajsLBQ+/fvDxSP7po/f76Ki4sDt71er7KysjR58uQzLr4r/H6/KioqNGnSJDmdTo0s2drjOcNpf0l+0O1wrs+VYPTImFYt2JsgX6uj2/O0X2Nn2q+7K/c5m9p/3eMJ2eMzuxTf+cke+extf7noim6Vj7vvvlsvvvii3njjDQ0ePDiwPSMjQ8ePH1djY6NSU1MD2xsaGpSRkdHpXC6XSy6Xq8N2p9MZ1gexbT7fie7/Ej4b2mc8G+vztTp6NG9Xvg7t5z9XfvjD/X0UTcgen9ml+M5P9shlD+XYIT3bxRiju+++Wxs3btSrr76qnJycoP2jR4+W0+lUZWVlYFtNTY1qa2vl8XhCORQAAIhRIZ35KCwsVHl5uX7729+qX79+qq+vlySlpKQoKSlJKSkpmjNnjoqLi9W/f3+53W7dc8898ng8PNMFAABICrF8rFmzRpL07W9/O2h7WVmZfvjDH0qSVq5cqYSEBBUUFMjn8yk/P1+rV68Oy2JxbujszecAAOiqkMpHV54Yk5iYqNLSUpWWlnZ7UQAAIHbx3i4AAMAqygcAALCqR69wCpxKZ9eFfLR0agRWAgA413DmAwAAWEX5AAAAVlE+AACAVVzzgTPidT0AAOHEmQ8AAGAV5QMAAFhF+QAAAFZxzUeExfP1FLwWCADEJ858AAAAqygfAADAKsoHAACwims+cE7juhAAiD2c+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYxYuMwZquvIlePL/RHgDEC858AAAAqygfAADAKsoHAACwivIBAACsonwAAACrKB8AAMAqygcAALAq5PLxxhtv6LrrrlNmZqYcDoc2bdoUtN8Yo4ULF2rQoEFKSkpSXl6eDhw4EK71AgCAKBdy+Th27Jguv/xylZaWdrp/+fLlevzxx7V27Vrt2rVL5513nvLz89XS0tLjxQIAgOgX8iucTpkyRVOmTOl0nzFGq1at0kMPPaRp06ZJkp5++mmlp6dr06ZNuvnmm3u2WgAAEPXC+vLqBw8eVH19vfLy8gLbUlJSNHbsWFVVVXVaPnw+n3w+X+C21+uVJPn9fvn9/h6vqW2Ots+uXqbHc0YLV4IJ+hwruvJ90f7rHk/IHp/ZpfjOT/bIZw/l+A5jTLd/MzkcDm3cuFE33HCDJGnHjh0aP3686urqNGjQoMC4m266SQ6HQ88991yHOUpKSrRo0aIO28vLy5WcnNzdpQEAAIuam5s1Y8YMNTU1ye12n3ZsxN9Ybv78+SouLg7c9nq9ysrK0uTJk8+4+K7w+/2qqKjQpEmT5HQ6NbJka4/njBauBKNHxrRqwd4E+VodkV7OWbO/JL/DtvZf9860/17obJ5o1JXssSqes0vxnZ/skc/e9peLrghr+cjIyJAkNTQ0BJ35aGho0BVXXNHpfVwul1wuV4ftTqczrA9i23y+E7H7S/hUfK2OmM59uu+T030ftX9MYu0frHD/DEWTeM4uxXd+skcueyjHDuvrfOTk5CgjI0OVlZWBbV6vV7t27ZLH4wnnoQAAQJQK+czH0aNH9eGHHwZuHzx4UPv27VP//v2VnZ2toqIiPfrooxo2bJhycnK0YMECZWZmBq4LAQAA8S3k8rF3715dc801gdtt12vMmjVLTz31lO6//34dO3ZMd9xxhxobGzVhwgRt2bJFiYmJ4Vs1cA4Z+uDvg25/tHRqhFYCANEh5PLx7W9/W6d7gozD4dDixYu1ePHiHi0MAADEJt7bBQAAWEX5AAAAVlE+AACAVZQPAABgFeUDAABYRfkAAABWRfy9XYCeav86G5J04JHJZxxjUyRfC6Sz7LwWCYBI4swHAACwivIBAACsonwAAACruOYDMWlkyVYtz/36s++Eo9vzRPpaEQCIRZz5AAAAVlE+AACAVZQPAABgFdd8AGHWletEuvLaG7w+B4BYxZkPAABgFeUDAABYRfkAAABWUT4AAIBVXHAKRJGuvEFdV15gLZJvdAcAnPkAAABWUT4AAIBVlA8AAGAV13wA54hYeBO7rmToyvUlvMAaENs48wEAAKyifAAAAKsoHwAAwCqu+QD+v1i45iKcuvJaIOF6zHjsT+9sXgPDa77EvnPxGirOfAAAAKsoHwAAwCrKBwAAsOqsXfNRWlqqn/3sZ6qvr9fll1+uJ554Qrm5uWfrcEBc6uxvua5e4ZnnXNOVNR54ZPIZ79Od1xnpyvUu4Xr9krP5tejK3OG6PuBcvM6gO7gm5uw4K2c+nnvuORUXF+vhhx/Wm2++qcsvv1z5+fk6fPjw2TgcAACIImelfKxYsUK33367Zs+erUsuuURr165VcnKyfv3rX5+NwwEAgCgS9j+7HD9+XNXV1Zo/f35gW0JCgvLy8lRVVdVhvM/nk8/nC9xuamqSJH3xxRfy+/09Xo/f71dzc7M+//xzOZ1O9f7qWI/njBa9W42am1vV25+gE62dv7V6rCJ7+LN//vnnHY/VjZ+ncM1zqrnP9PPe2fHPtJ6urLk783Z2v64+Fp0dr/2/d105fnePdSbdfey760zZu6s7X2fbuvN1Pxs5jhw5Ikkyxpx5sAmzTz/91EgyO3bsCNo+b948k5ub22H8ww8/bCTxwQcffPDBBx8x8PHJJ5+csStE/EXG5s+fr+Li4sDt1tZWffHFF0pLS5PD0fP/a/N6vcrKytInn3wit9vd4/miCdnJTvb4Es/5yR757MYYHTlyRJmZmWccG/byMWDAAPXq1UsNDQ1B2xsaGpSRkdFhvMvlksvlCtqWmpoa7mXJ7XbH3TdkG7KTPd7Ec3YpvvOTPbLZU1JSujQu7Bec9unTR6NHj1ZlZWVgW2trqyorK+XxeMJ9OAAAEGXOyp9diouLNWvWLI0ZM0a5ublatWqVjh07ptmzZ5+NwwEAgChyVsrH9773Pf3f//2fFi5cqPr6el1xxRXasmWL0tPTz8bhTsvlcunhhx/u8KedeEB2ssebeM4uxXd+skdXdocxXXlODAAAQHjw3i4AAMAqygcAALCK8gEAAKyifAAAAKtivnyUlpZq6NChSkxM1NixY7V79+5IL6lHlixZoquuukr9+vXTwIEDdcMNN6impiZoTEtLiwoLC5WWlqa+ffuqoKCgw4u+1dbWaurUqUpOTtbAgQM1b948ffXVVzaj9NjSpUvlcDhUVFQU2BbL2T/99FN9//vfV1pampKSkjRq1Cjt3bs3sN8Yo4ULF2rQoEFKSkpSXl6eDhw4EDTHF198oZkzZ8rtdis1NVVz5szR0aNHbUcJyYkTJ7RgwQLl5OQoKSlJF110kR555JGg94+IpexvvPGGrrvuOmVmZsrhcGjTpk1B+8OV9Z133tE//uM/KjExUVlZWVq+fPnZjnZGp8vu9/v1wAMPaNSoUTrvvPOUmZmpH/zgB6qrqwuaIxazt3fnnXfK4XBo1apVQdujKnvP383l3LV+/XrTp08f8+tf/9q899575vbbbzepqammoaEh0kvrtvz8fFNWVmb2799v9u3bZ/75n//ZZGdnm6NHjwbG3HnnnSYrK8tUVlaavXv3mnHjxpmrr746sP+rr74yI0eONHl5eeatt94yL730khkwYICZP39+JCJ1y+7du83QoUPNZZddZu67777A9ljN/sUXX5ghQ4aYH/7wh2bXrl3mz3/+s9m6dav58MMPA2OWLl1qUlJSzKZNm8zbb79trr/+epOTk2P++te/Bsb80z/9k7n88svNzp07zR//+Efz93//9+aWW26JRKQue+yxx0xaWpp58cUXzcGDB82GDRtM3759zS9+8YvAmFjK/tJLL5mf/OQn5oUXXjCSzMaNG4P2hyNrU1OTSU9PNzNnzjT79+83zz77rElKSjK//OUvbcXs1OmyNzY2mry8PPPcc8+Z//mf/zFVVVUmNzfXjB49OmiOWMx+shdeeMFcfvnlJjMz06xcuTJoXzRlj+nykZubawoLCwO3T5w4YTIzM82SJUsiuKrwOnz4sJFktm3bZoz5+gfU6XSaDRs2BMb86U9/MpJMVVWVMebrb/KEhARTX18fGLNmzRrjdruNz+ezG6Abjhw5YoYNG2YqKirMt771rUD5iOXsDzzwgJkwYcIp97e2tpqMjAzzs5/9LLCtsbHRuFwu8+yzzxpjjHn//feNJLNnz57AmJdfftk4HA7z6aefnr3F99DUqVPNbbfdFrRt+vTpZubMmcaY2M7e/pdQuLKuXr3anH/++UHf8w888IC5+OKLz3KirjvdL+A2u3fvNpLMxx9/bIyJ/ex/+ctfzIUXXmj2799vhgwZElQ+oi17zP7Z5fjx46qurlZeXl5gW0JCgvLy8lRVVRXBlYVXU1OTJKl///6SpOrqavn9/qDcw4cPV3Z2diB3VVWVRo0aFfSib/n5+fJ6vXrvvfcsrr57CgsLNXXq1KCMUmxn/93vfqcxY8boxhtv1MCBA3XllVfqV7/6VWD/wYMHVV9fH5Q9JSVFY8eODcqempqqMWPGBMbk5eUpISFBu3btshcmRFdffbUqKyv1wQcfSJLefvttbd++XVOmTJEU29nbC1fWqqoqffOb31SfPn0CY/Lz81VTU6Mvv/zSUpqea2pqksPhCLwfWCxnb21t1a233qp58+bp0ksv7bA/2rLHbPn47LPPdOLEiQ6vqpqenq76+voIrSq8WltbVVRUpPHjx2vkyJGSpPr6evXp06fDm/OdnLu+vr7Tx6Vt37ls/fr1evPNN7VkyZIO+2I5+5///GetWbNGw4YN09atW/WjH/1I9957r/7zP/9T0t/Wfrrv9/r6eg0cODBof+/evdW/f/9zOvuDDz6om2++WcOHD5fT6dSVV16poqIizZw5U1JsZ28vXFmj9efgZC0tLXrggQd0yy23BN5MLZazL1u2TL1799a9997b6f5oy35WXl4ddhQWFmr//v3avn17pJdixSeffKL77rtPFRUVSkxMjPRyrGptbdWYMWP005/+VJJ05ZVXav/+/Vq7dq1mzZoV4dWdXc8//7yeeeYZlZeX69JLL9W+fftUVFSkzMzMmM+Ozvn9ft10000yxmjNmjWRXs5ZV11drV/84hd688035XA4Ir2csIjZMx8DBgxQr169OjzToaGhQRkZGRFaVfjcfffdevHFF/Xaa69p8ODBge0ZGRk6fvy4Ghsbg8afnDsjI6PTx6Vt37mqurpahw8f1j/8wz+od+/e6t27t7Zt26bHH39cvXv3Vnp6esxmHzRokC655JKgbSNGjFBtba2kv639dN/vGRkZOnz4cND+r776Sl988cU5nX3evHmBsx+jRo3Srbfeqrlz5wbOfsVy9vbClTVafw6kvxWPjz/+WBUVFUFvIR+r2f/4xz/q8OHDys7ODvzb9/HHH+vHP/6xhg4dKin6ssds+ejTp49Gjx6tysrKwLbW1lZVVlbK4/FEcGU9Y4zR3XffrY0bN+rVV19VTk5O0P7Ro0fL6XQG5a6pqVFtbW0gt8fj0bvvvhv0jdr2Q9z+F9y55Nprr9W7776rffv2BT7GjBmjmTNnBv47VrOPHz++w1OqP/jgAw0ZMkSSlJOTo4yMjKDsXq9Xu3btCsre2Nio6urqwJhXX31Vra2tGjt2rIUU3dPc3KyEhOB/qnr16qXW1lZJsZ29vXBl9Xg8euONN+T3+wNjKioqdPHFF+v888+3lCZ0bcXjwIEDeuWVV5SWlha0P1az33rrrXrnnXeC/u3LzMzUvHnztHXrVklRmN36Ja4WrV+/3rhcLvPUU0+Z999/39xxxx0mNTU16JkO0eZHP/qRSUlJMa+//ro5dOhQ4KO5uTkw5s477zTZ2dnm1VdfNXv37jUej8d4PJ7A/ranm06ePNns27fPbNmyxVxwwQXn/NNNO3Pys12Mid3su3fvNr179zaPPfaYOXDggHnmmWdMcnKy+c1vfhMYs3TpUpOammp++9vfmnfeecdMmzat06dgXnnllWbXrl1m+/btZtiwYefk001PNmvWLHPhhRcGnmr7wgsvmAEDBpj7778/MCaWsh85csS89dZb5q233jKSzIoVK8xbb70VeEZHOLI2Njaa9PR0c+utt5r9+/eb9evXm+Tk5Ig/3fR02Y8fP26uv/56M3jwYLNv376gf/9OfvZGLGbvTPtnuxgTXdljunwYY8wTTzxhsrOzTZ8+fUxubq7ZuXNnpJfUI5I6/SgrKwuM+etf/2ruuusuc/7555vk5GTz3e9+1xw6dChono8++shMmTLFJCUlmQEDBpgf//jHxu/3W07Tc+3LRyxn37x5sxk5cqRxuVxm+PDh5sknnwza39raahYsWGDS09ONy+Uy1157rampqQka8/nnn5tbbrnF9O3b17jdbjN79mxz5MgRmzFC5vV6zX333Weys7NNYmKi+bu/+zvzk5/8JOgXTixlf+211zr9GZ81a5YxJnxZ3377bTNhwgTjcrnMhRdeaJYuXWor4imdLvvBgwdP+e/fa6+9FpgjFrN3prPyEU3ZHcac9DKBAAAAZ1nMXvMBAADOTZQPAABgFeUDAABYRfkAAABWUT4AAIBVlA8AAGAV5QMAAFhF+QAAAFZRPgAAgFWUDwAAYBXlAwAAWEX5AAAAVv0/zpSarRt+e1IAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "census_addresses_per_zip.hist(bins=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "id": "8b595e14",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count     857.000000\n",
+       "mean      221.512252\n",
+       "std       199.989439\n",
+       "min         9.000000\n",
+       "25%        82.000000\n",
+       "50%       176.000000\n",
+       "75%       299.000000\n",
+       "max      1438.000000\n",
+       "Name: address_id, dtype: float64"
+      ]
+     },
+     "execution_count": 120,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "census_addresses_per_zip.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "id": "b5cb333d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9.283387940730599"
+      ]
+     },
+     "execution_count": 121,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_census.address_id.nunique() / len(address_to_zip)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6df95162",
+   "metadata": {},
+   "source": [
+    "# Save zipcode mapping to use later"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "id": "4a4f34c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prl  vivarium_lsff  vivarium_results\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls /share/scratch/users/ndbs/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 135,
+   "id": "ac497f02",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 16580\n",
+      "-rw-rw-r-- 1 ndbs Domain Users 16972022 Feb  8 15:36 census_index_to_zipcode_2023_02_02_10_16_21.csv.bz2\n",
+      "CPU times: user 10.4 s, sys: 16.4 ms, total: 10.4 s\n",
+      "Wall time: 10.9 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "save_dir = '/share/scratch/users/ndbs/prl'\n",
+    "save_filename = 'census_index_to_zipcode_2023_02_02_10_16_21.csv.bz2'\n",
+    "save_filepath = f'{save_dir}/{save_filename}'\n",
+    "census_zips['zipcode'].to_csv(save_filepath)\n",
+    "!ls -l $save_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "id": "f52b6e39",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5.76 s, sys: 283 ms, total: 6.04 s\n",
+      "Wall time: 6.04 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>zipcode</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>33462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>33462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>33811</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>32730</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943280</th>\n",
+       "      <td>34741</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943281</th>\n",
+       "      <td>33993</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943282</th>\n",
+       "      <td>32792</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943283</th>\n",
+       "      <td>34224</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4943284</th>\n",
+       "      <td>33914</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>4943285 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        zipcode\n",
+       "0         33462\n",
+       "1         33462\n",
+       "2         33462\n",
+       "3         33811\n",
+       "4         32730\n",
+       "...         ...\n",
+       "4943280   34741\n",
+       "4943281   33993\n",
+       "4943282   32792\n",
+       "4943283   34224\n",
+       "4943284   33914\n",
+       "\n",
+       "[4943285 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 136,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "loaded_zips = pd.read_csv(save_filepath, index_col=0, dtype=str)\n",
+    "loaded_zips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "id": "d5a92c59",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "zipcode    object\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 137,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loaded_zips.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "id": "4ca89d02",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Int64Index([      0,       1,       2,       3,       4,       5,       6,\n",
+       "                  7,       8,       9,\n",
+       "            ...\n",
+       "            4943275, 4943276, 4943277, 4943278, 4943279, 4943280, 4943281,\n",
+       "            4943282, 4943283, 4943284],\n",
+       "           dtype='int64', length=4943285)"
+      ]
+     },
+     "execution_count": 138,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loaded_zips.index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c505a326",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a notebook that uses the state table data with timestamp `2022_10_14_10_49_32` to assign a zipcode to each address ID in the census and WIC data with timestamp `2023_02_02_10_16_21`, in such a way that the distribution of the number of addresses per zipcode is approximately preserved.